### PR TITLE
Add doubleqoutes to allow special chars

### DIFF
--- a/deployment_scripts/linode-marketplace-docker/docker-deploy.sh
+++ b/deployment_scripts/linode-marketplace-docker/docker-deploy.sh
@@ -44,7 +44,7 @@ function udf {
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-focalboard/focalboard-deploy.sh
+++ b/deployment_scripts/linode-marketplace-focalboard/focalboard-deploy.sh
@@ -49,7 +49,7 @@ function udf {
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-harbor/harbor-deploy.sh
+++ b/deployment_scripts/linode-marketplace-harbor/harbor-deploy.sh
@@ -46,7 +46,7 @@ function udf {
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-joplin/joplin-deploy.sh
+++ b/deployment_scripts/linode-marketplace-joplin/joplin-deploy.sh
@@ -47,7 +47,7 @@ function udf {
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-keplerbuilder/keplerbuilder-deploy.sh
+++ b/deployment_scripts/linode-marketplace-keplerbuilder/keplerbuilder-deploy.sh
@@ -57,7 +57,7 @@ EOF
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-lamp/lamp-deploy.sh
+++ b/deployment_scripts/linode-marketplace-lamp/lamp-deploy.sh
@@ -47,7 +47,7 @@ EOF
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-lemp/lemp-deploy.sh
+++ b/deployment_scripts/linode-marketplace-lemp/lemp-deploy.sh
@@ -47,7 +47,7 @@ EOF
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-mc-ffmpeg-demo/mc-ffmpeg-demo-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mc-ffmpeg-demo/mc-ffmpeg-demo-deploy.sh
@@ -37,7 +37,7 @@ EOF
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-mc-live-encoder-demo/mc-live-encoder-demo-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mc-live-encoder-demo/mc-live-encoder-demo-deploy.sh
@@ -44,7 +44,7 @@ EOF
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-mc-p2-avc-demo/mc-p2-avc-demo-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mc-p2-avc-demo/mc-p2-avc-demo-deploy.sh
@@ -48,7 +48,7 @@ EOF
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-mc-xavc-demo/mc-xavc-demo-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mc-xavc-demo/mc-xavc-demo-deploy.sh
@@ -47,7 +47,7 @@ EOF
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-mc-xdcam-demo/mc-xdcam-demo-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mc-xdcam-demo/mc-xdcam-demo-deploy.sh
@@ -47,7 +47,7 @@ EOF
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-nextcloud/nextcloud-deploy.sh
+++ b/deployment_scripts/linode-marketplace-nextcloud/nextcloud-deploy.sh
@@ -45,7 +45,7 @@ function udf {
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-nirvashare/nirvashare-deploy.sh
+++ b/deployment_scripts/linode-marketplace-nirvashare/nirvashare-deploy.sh
@@ -46,7 +46,7 @@ function udf {
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-odoo/odoo-deploy.sh
+++ b/deployment_scripts/linode-marketplace-odoo/odoo-deploy.sh
@@ -46,7 +46,7 @@ function udf {
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-openvpn/openvpn-deploy.sh
+++ b/deployment_scripts/linode-marketplace-openvpn/openvpn-deploy.sh
@@ -46,7 +46,7 @@ function udf {
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-peppermint/peppermint-deploy.sh
+++ b/deployment_scripts/linode-marketplace-peppermint/peppermint-deploy.sh
@@ -47,7 +47,7 @@ function udf {
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-secure-your-server/secure-your-server-deploy.sh
+++ b/deployment_scripts/linode-marketplace-secure-your-server/secure-your-server-deploy.sh
@@ -43,7 +43,7 @@ function udf {
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-simplex-chat/simplex-deploy.sh
+++ b/deployment_scripts/linode-marketplace-simplex-chat/simplex-deploy.sh
@@ -74,7 +74,7 @@ function udf {
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-uptimekuma/uptimekuma-deploy.sh
+++ b/deployment_scripts/linode-marketplace-uptimekuma/uptimekuma-deploy.sh
@@ -49,7 +49,7 @@ function udf {
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-woocommerce/woocommerce-deploy.sh
+++ b/deployment_scripts/linode-marketplace-woocommerce/woocommerce-deploy.sh
@@ -57,7 +57,7 @@ EOF
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-wordpress/wordpress-deploy.sh
+++ b/deployment_scripts/linode-marketplace-wordpress/wordpress-deploy.sh
@@ -57,7 +57,7 @@ EOF
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 

--- a/deployment_scripts/linode-marketplace-yacht/yacht-deploy.sh
+++ b/deployment_scripts/linode-marketplace-yacht/yacht-deploy.sh
@@ -49,7 +49,7 @@ function udf {
   fi
 
   if [[ -n ${PASSWORD} ]]; then
-    echo "password: ${PASSWORD}" >> ${group_vars};
+    echo "password: \"${PASSWORD}\"" >> ${group_vars};
   else echo "No password entered";
   fi
 


### PR DESCRIPTION
This PR addresses OCA-1266

Current implementation fails to deploy for all apps using a password like {}#$(*GFHinh33t3

This PR fixes that :)