### PR TITLE
temporary fix to apt helper for ubuntu outage

### DIFF
--- a/apps/linode_helpers/roles/update_pkgs/tasks/main.yml
+++ b/apps/linode_helpers/roles/update_pkgs/tasks/main.yml
@@ -2,7 +2,13 @@
 - name: apt update
   apt:
     update_cache: yes
+  ignore_errors: true # tempporary fix 
 
 - name: apt upgrade
   apt:
     upgrade: full
+  ignore_errors: true # temporary fix
+
+# ignore errors temporary for duration of ubuntu outage
+# https://status.canonical.com/#/incident/KNms6QK9ewuzz-7xUsPsNylV20jEt5kyKsd8A-3ptQG-R6bil1_KnGrNhlmDfGeBqxPulG7NPS3y2X0ZcEptVQ== # temporary fix
+


### PR DESCRIPTION
See outage here: https://status.canonical.com/#/incident/KNms6QK9ewuzz-7xUsPsNylV20jEt5kyKsd8A-3ptQG-R6bil1_KnGrNhlmDfGeBqxPulG7NPS3y2X0ZcEptVQ==

Temporarily adding `ignore_errors: true` to apt update helper in the meantime to resolve broken marketplace deployments. Remove after upstream incident is resolved.