### PR TITLE
[fix] BeEF DNS creation

### DIFF
--- a/apps/linode-marketplace-beef/requirements.txt
+++ b/apps/linode-marketplace-beef/requirements.txt
@@ -3,7 +3,7 @@ PyMySQL==1.0.2
 yamllint==1.26.2
 ansible-lint==6.0.1
 flake8==3.9.2
-linode_api4==5.5.0
+linode_api4==5.24.0
 dnspython==2.2.1
 polling==0.3.2
 ansible-specdoc==0.0.14

--- a/apps/linode-marketplace-openbao/README.md
+++ b/apps/linode-marketplace-openbao/README.md
@@ -8,7 +8,7 @@ OpenBao is an open source solution to manage, store, and distribute sensitive da
 
 | Software  | Version   | Description   |
 | :---      | :----     | :---          |
-| Openbao    | v2.0.0-alpha20240329    | Secrets Management tool |
+| Openbao    | v2.0.2    | Secrets Management tool |
 
 
 **Supported Distributions:**


### PR DESCRIPTION
Linode_api4 version needed to be updated along with the recent updates we made to beef. Normal default RDNS worked, but with domain it errored out. Updating to latest linode_api4 resolves the issue

linode_api4==5.24.0