### PR TITLE
[Update] DNS & Certbot Helpers

### DIFF
--- a/apps/linode_helpers/roles/certbot_ssl/tasks/apache-certbot.yml
+++ b/apps/linode_helpers/roles/certbot_ssl/tasks/apache-certbot.yml
@@ -10,6 +10,10 @@
     certbot_plugin: apache
     cacheable: yes
 
+- name:  dry-run certbot
+  include_tasks:
+    file: dry-run.yml
+
 - name: installing let's encrypt certificate on subdomain provided via UDF
   shell:
     cmd: "certbot -n --apache --agree-tos --redirect -d {{ subdomain }}.{{ domain }} -m {{ soa_email_address }}"

--- a/apps/linode_helpers/roles/certbot_ssl/tasks/dry-run.yml
+++ b/apps/linode_helpers/roles/certbot_ssl/tasks/dry-run.yml
@@ -1,0 +1,49 @@
+# certbot dry-runs
+- name: set stack variable based on webserver_stack
+  set_fact:
+    webserver: >-
+      {{ 'apache' if webserver_stack == 'lamp'
+         else 'nginx' if webserver_stack == 'lemp'
+         else 'standalone' if webserver_stack == 'standalone' }}
+
+- name: run dry-run for subdomain
+  shell:
+    cmd: "certbot -n --{{ webserver }} --agree-tos --dry-run --redirect certonly -d {{ subdomain }}.{{ domain }} -m {{ soa_email_address }}"
+  register: dry_run
+  until: dry_run is not failed
+  retries: 3
+  delay: 3
+  ignore_errors: true
+  when: 
+    - domain is defined
+    - subdomain != 'www' 
+
+- name: run dry-run for tld and default subdomain
+  shell:
+    cmd: "certbot -n --{{ webserver }} --agree-tos --dry-run --redirect certonly -d {{ domain }} -d {{ subdomain }}.{{ domain }} -m {{ soa_email_address }}"
+  register: dry_run
+  until: dry_run is not failed
+  retries: 3
+  delay: 3
+  ignore_errors: true
+  when:
+    - domain is defined
+    - subdomain == 'www' 
+
+- name: run dry-run for default domain
+  shell:
+    cmd: "certbot -n --{{ webserver }} --agree-tos --dry-run --redirect certonly -d {{ default_dns }} -m {{ soa_email_address }}"
+  register: dry_run
+  until: dry_run is not failed
+  retries: 3
+  delay: 3
+  ignore_errors: true
+  when: default_dns is defined
+
+# assert that we can get valid certs. Otherwise fail - can't achieve final state
+- name: validate certbot dry-run
+  assert:
+    that: dry_run is not failed
+    fail_msg: "[Error] Certbot dry-run domain. Please check /var/log/letsencrypt/letsencrypt.log"
+    success_msg: "[Info] Certbot dry-run successful!"
+  run_once: true

--- a/apps/linode_helpers/roles/certbot_ssl/tasks/nginx-certbot.yml
+++ b/apps/linode_helpers/roles/certbot_ssl/tasks/nginx-certbot.yml
@@ -10,6 +10,10 @@
     certbot_plugin: nginx
     cacheable: yes
 
+- name:  dry-run certbot
+  include_tasks:
+    file: dry-run.yml
+
 - name: installing let's encrypt certificate on subdomain provided via UDF
   shell:
     cmd: "certbot -n --nginx --agree-tos --redirect -d {{ subdomain }}.{{ domain }} -m {{ soa_email_address }}"

--- a/apps/linode_helpers/roles/certbot_ssl/tasks/standalone-certbot.yml
+++ b/apps/linode_helpers/roles/certbot_ssl/tasks/standalone-certbot.yml
@@ -10,52 +10,11 @@
     certbot_plugin: standalone
     cacheable: yes
 
-# certbot dry-runs
-- name: run dry-run for subdomain
-  shell:
-    cmd: "certbot -n --standalone --agree-tos --dry-run --redirect certonly -d {{ subdomain }}.{{ domain }} -m {{ soa_email_address }}"
-  register: dry_run
-  until: dry_run is not failed
-  retries: 3
-  delay: 3
-  ignore_errors: true
-  when: 
-    - domain is defined
-    - subdomain != 'www'  
-
-- name: run dry-run for tld and default subdomain
-  shell:
-    cmd: "certbot -n --standalone --agree-tos --dry-run --redirect certonly -d {{ domain }} -d {{ subdomain }}.{{ domain }} -m {{ soa_email_address }}"
-  register: dry_run
-  until: dry_run is not failed
-  retries: 3
-  delay: 3
-  ignore_errors: true
-  when:
-    - domain is defined
-    - subdomain == 'www' 
-
-- name: run dry-run for default domain
-  shell:
-    cmd: "certbot -n --standalone --agree-tos --dry-run --redirect certonly -d {{ default_dns }} -m {{ soa_email_address }}"
-  register: dry_run
-  until: dry_run is not failed
-  retries: 3
-  delay: 3
-  ignore_errors: true
-  when: default_dns is defined
-
-# assert that we can get valid certs. Otherwise fail - can't achieve final state
-
-- name: validate certbot dry-run
-  assert:
-    that: dry_run is not failed
-    fail_msg: "[Error] Certbot dry-run domain. Please check /var/log/letsencrypt/letsencrypt.log"
-    success_msg: "[Info] Certbot dry-run successful!"
-  run_once: true
-
+- name:  dry-run certbot
+  include_tasks:
+    file: dry-run.yml
+    
 # get certs
-
 - name: installing let's encrypt certificate on subdomain provided via UDF
   shell:
     cmd: "certbot -n --standalone --agree-tos --redirect certonly -d {{ subdomain }}.{{ domain }} -m {{ soa_email_address }}"

--- a/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
+++ b/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
@@ -72,9 +72,11 @@
 - name: wait for DNS propagation domain
   debug:
     msg: waiting for DNS propagation
-  until: "{{ lookup('community.general.dig', domain) == ip_address }}"
-  retries: 30
-  delay: 10
+  until: "{{ lookup('community.general.dig', domain) }}"
+  register: dig_result
+  until: ip_address.msg in dig_result.msg
+  retries: 50
+  delay: 15
   when:
     - domain is defined
     - subdomain == "www"
@@ -83,8 +85,10 @@
   debug:
     msg: waiting for DNS propagation
   until: "{{ lookup('community.general.dig', subdomain + '.' + domain) }}"
-  retries: 30
-  delay: 10
+  register: dig_result
+  until: ip_address.msg in dig_result.msg
+  retries: 50
+  delay: 15
   when: subdomain is defined
 
 # Double check to make sure it propogated elsewhere (using google's DNS servers)

--- a/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
+++ b/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
@@ -95,7 +95,7 @@
     msg: "{{ lookup('community.general.dig', domain, '@8.8.8.8') }}"
   register: dig_result
   until: ip_address.msg in dig_result.msg
-  retries: 20
+  retries: 50
   delay: 10
   when:
     - domain is defined
@@ -106,6 +106,6 @@
     msg: "{{ lookup('community.general.dig', subdomain + '.' + domain, '@8.8.8.8') }}"
   register: dig_result
   until: ip_address.msg in dig_result.msg
-  retries: 20
+  retries: 50
   delay: 10
   when: subdomain is defined

--- a/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
+++ b/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
@@ -69,23 +69,21 @@
     state: present
   when: subdomain is defined
 
-- name: Check for DNS propogation locally if using domain
+- name: wait for DNS propagation domain
   debug:
-    msg: "{{ lookup('community.general.dig', domain) }}"
-  register: dig_result
-  until: ip_address.msg in dig_result.msg
-  retries: 10
+    msg: waiting for DNS propagation
+  until: "{{ lookup('community.general.dig', domain) == ip_address }}"
+  retries: 30
   delay: 10
   when:
     - domain is defined
     - subdomain == "www"
 
-- name: Check for DNS propogation locally if using subdomain
+- name: wait for DNS propagation subdomain
   debug:
-    msg: "{{ lookup('community.general.dig', subdomain + '.' + domain) }}"
-  register: dig_result
-  until: ip_address.msg in dig_result.msg
-  retries: 10
+    msg: waiting for DNS propagation
+  until: "{{ lookup('community.general.dig', subdomain + '.' + domain) }}"
+  retries: 30
   delay: 10
   when: subdomain is defined
 
@@ -96,7 +94,7 @@
   register: dig_result
   until: ip_address.msg in dig_result.msg
   retries: 50
-  delay: 10
+  delay: 15
   when:
     - domain is defined
     - subdomain == "www"
@@ -107,5 +105,5 @@
   register: dig_result
   until: ip_address.msg in dig_result.msg
   retries: 50
-  delay: 10
+  delay: 15
   when: subdomain is defined

--- a/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
+++ b/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
@@ -69,25 +69,25 @@
     state: present
   when: subdomain is defined
 
-- name: wait for DNS propagation domain
-  debug:
-    msg: waiting for DNS propagation
-  until: "{{ lookup('community.general.dig', domain) }}"
-  register: dig_result
-  until: ip_address.msg in dig_result.msg
-  retries: 10
-  delay: 15
-  when:
-    - domain is defined
-    - subdomain == "www"
+# - name: wait for DNS propagation domain
+#   debug:
+#     msg: waiting for DNS propagation
+#   until: "{{ lookup('community.general.dig', domain) }}"
+#   register: dig_result
+#   until: ip_address.msg in dig_result.msg
+#   retries: 10
+#   delay: 15
+#   when:
+#     - domain is defined
+#     - subdomain == "www"
 
-- name: wait for DNS propagation subdomain
-  debug:
-    msg: waiting for DNS propagation
-  until: "{{ lookup('community.general.dig', subdomain + '.' + domain) }}"
-  register: dig_result
-  until: ip_address.msg in dig_result.msg
-  retries: 10
-  delay: 15
-  when: subdomain is defined
+# - name: wait for DNS propagation subdomain
+#   debug:
+#     msg: waiting for DNS propagation
+#   until: "{{ lookup('community.general.dig', subdomain + '.' + domain) }}"
+#   register: dig_result
+#   until: ip_address.msg in dig_result.msg
+#   retries: 10
+#   delay: 15
+#   when: subdomain is defined
 

--- a/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
+++ b/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
@@ -69,11 +69,27 @@
     state: present
   when: subdomain is defined
 
-- name: wait for DNS propogation
-  ansible.builtin.pause: 
-    minutes: 3
+- name: Check for DNS propogation locally if using domain
+  debug:
+    msg: "{{ lookup('community.general.dig', domain) }}"
+  register: dig_result
+  until: ip_address.msg in dig_result.msg
+  retries: 10
+  delay: 10
+  when:
+    - domain is defined
+    - subdomain == "www"
 
-# it is recommended to use an external DNS resolver for domain validation
+- name: Check for DNS propogation locally if using subdomain
+  debug:
+    msg: "{{ lookup('community.general.dig', subdomain + '.' + domain) }}"
+  register: dig_result
+  until: ip_address.msg in dig_result.msg
+  retries: 10
+  delay: 10
+  when: subdomain is defined
+
+# Double check to make sure it propogated elsewhere (using google's DNS servers)
 - name: A record lookup for domain
   debug:
     msg: "{{ lookup('community.general.dig', domain, '@8.8.8.8') }}"

--- a/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
+++ b/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
@@ -95,7 +95,7 @@
     msg: "{{ lookup('community.general.dig', domain, '@8.8.8.8') }}"
   register: dig_result
   until: ip_address.msg in dig_result.msg
-  retries: 5
+  retries: 20
   delay: 10
   when:
     - domain is defined
@@ -106,6 +106,6 @@
     msg: "{{ lookup('community.general.dig', subdomain + '.' + domain, '@8.8.8.8') }}"
   register: dig_result
   until: ip_address.msg in dig_result.msg
-  retries: 5
+  retries: 20
   delay: 10
   when: subdomain is defined

--- a/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
+++ b/apps/linode_helpers/roles/create_dns_record/tasks/main.yml
@@ -75,7 +75,7 @@
   until: "{{ lookup('community.general.dig', domain) }}"
   register: dig_result
   until: ip_address.msg in dig_result.msg
-  retries: 50
+  retries: 10
   delay: 15
   when:
     - domain is defined
@@ -87,27 +87,7 @@
   until: "{{ lookup('community.general.dig', subdomain + '.' + domain) }}"
   register: dig_result
   until: ip_address.msg in dig_result.msg
-  retries: 50
+  retries: 10
   delay: 15
   when: subdomain is defined
 
-# Double check to make sure it propogated elsewhere (using google's DNS servers)
-- name: A record lookup for domain
-  debug:
-    msg: "{{ lookup('community.general.dig', domain, '@8.8.8.8') }}"
-  register: dig_result
-  until: ip_address.msg in dig_result.msg
-  retries: 50
-  delay: 15
-  when:
-    - domain is defined
-    - subdomain == "www"
-
-- name: A record lookup for subdomain
-  debug:
-    msg: "{{ lookup('community.general.dig', subdomain + '.' + domain, '@8.8.8.8') }}"
-  register: dig_result
-  until: ip_address.msg in dig_result.msg
-  retries: 50
-  delay: 15
-  when: subdomain is defined


### PR DESCRIPTION
[Update] DNS & Certbot Helpers:

Our current implementation of our DNS helpers blindly waits for 3 minutes to propogate DNS. It works in current production but does take additional time when DNS is needed. This PR removes the dns propogation and replaces it with a dryrun for letsencrypt which will automatically check for that & retry, so no need for DNS propogation check :)