### PR TITLE
Update to OpenBao v2.4.0

### DIFF
--- a/apps/linode-marketplace-openbao/roles/openbao/defaults/main.yml
+++ b/apps/linode-marketplace-openbao/roles/openbao/defaults/main.yml
@@ -2,8 +2,8 @@
 ## OpenBao is still in active development, so the openbao_download_link and the openbao_deb_file will need to actively be monitored for latest released here https://openbao.org/downloads/
 
 # global vars
-openbao_version: v2.0.3
-openbao_download_link: https://github.com/openbao/openbao/releases/download/v2.0.3/bao_2.0.3_linux_amd64.deb
-openbao_deb_file: /tmp/bao_2.0.3_linux_amd64.deb
+openbao_version: v2.4.0
+openbao_download_link: https://github.com/openbao/openbao/releases/download/v2.4.0/bao_2.4.0_linux_amd64.deb
+openbao_deb_file: /tmp/bao_2.4.0_linux_amd64.deb
 openbao_config: /etc/openbao/openbao.hcl
 openbao_ssl_path: /opt/openbao/tls

--- a/apps/linode-marketplace-openbao/roles/openbao/templates/openbao.hcl.j2
+++ b/apps/linode-marketplace-openbao/roles/openbao/templates/openbao.hcl.j2
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # Full configuration options can be found at https://github.com/openbao/openbao/tree/main/website/content/docs/configuration
-## UI not available as of 06/24/2024
-#ui = true
+ui = true
 
 #mlock = true
 #disable_mlock = true
@@ -41,6 +40,15 @@ api_addr = "https://{{ ansible_default_ipv4.address }}:8200"
 # address openbao nodes will use to communicate with each other within the cluster
 # required option for Raft storage
 cluster_addr = "https://{{ privateip }}:8201"
+
+# This enables an audit device which writes audit logs to /dev/stdout
+# so they can be filtered separately from server logs written to /dev/stderr.
+audit "file" "stdout" {
+  description = "Log audit events to /dev/stdout"
+  options = {
+    "file_path" = "stdout"
+  }
+}
 
 # Example AWS KMS auto unseal
 #seal "awskms" {


### PR DESCRIPTION
OpenBao has included the UI since v2.2.x. As a result of security vulnerabilities disclosed by HashiCorp in the v2.3.x series, the v2.4.x series has introduced configuration-based audit devices. An example of this has been enabled in the configuration file (writing to /dev/stdout).