### PR TITLE
[CI/CD] Adding permission check & approval step

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -3,11 +3,56 @@ on:
   workflow_dispatch:
   pull_request_target:
 jobs:
+  check-workflow-permissions-job:
+    name: Check workflow permissions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      environment: ${{ steps.check-permissions.outputs.environment }}
+    env:
+      AUTHOR_NAME: ${{ github.event.pull_request.user.login || github.actor }}
+      AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association || 'COLLABORATOR' }}
+      PR_NUMBER: ${{ github.event.pull_request.number || 'branch' }}
+      BRANCH: ${{ github.head_ref || github.ref_name }}
+      TARGET: ${{ github.event.pull_request.base.ref || 'main'}}
+    steps:
+      - name: Check author permissions
+        id: check-permissions
+        run: |
+          if [[ "$AUTHOR_ASSOCIATION" =~ ^(COLLABORATOR|MEMBER|OWNER)$ ]]; then
+            echo "environment=development_internal" >> $GITHUB_OUTPUT
+          else
+            echo "environment=development_external" >> $GITHUB_OUTPUT
+          fi
+      - name: Print permissions summary
+        run: |
+          echo "## Permissions Summary" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| **Author name** | ${{ env.AUTHOR_NAME }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Author Association** | ${{ env.AUTHOR_ASSOCIATION }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **PR** | ${{ env.PR_NUMBER }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Branch** | ${{ env.BRANCH }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Target** | ${{ env.TARGET }} |" >> $GITHUB_STEP_SUMMARY
+  approve-workflow-job:
+    name: Approve workflow
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: ${{ needs.check-workflow-permissions-job.outputs.environment }}
+    needs: check-workflow-permissions-job
+    steps:
+      - name: Print deployment summary
+        run: |
+          echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Deployment has been approved and started to \`${{ needs.check-workflow-permissions-job.outputs.environment }}\`" >> $GITHUB_STEP_SUMMARY
   static-code-analysis-shellcheck:
     name: Static code analysis - shellcheck
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs: approve-workflow-job
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -20,6 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs: approve-workflow-job
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -32,6 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs: approve-workflow-job
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Once workflow is triggered it checks **author permissions** and provide summary:
![Screenshot 2026-03-11 at 12 07 58 PM](https://github.com/user-attachments/assets/74cdee1e-b25a-44e0-93e8-c707aabc29f0)

In case if author is **owner or collaborator** - workflow is approved automatically (env: development_internal)
![Screenshot 2026-03-11 at 12 32 55 PM](https://github.com/user-attachments/assets/3178b43d-17be-4df1-b0a4-cfeff0b482ce)

In case if author is **external contributor** - workflow require approval (env: development_external)
![Screenshot 2026-03-11 at 12 08 15 PM](https://github.com/user-attachments/assets/2e554031-c1a3-4ebc-ae1e-7d5f85524a33)

if it's **rejected** - workflow stops
![Screenshot 2026-03-11 at 12 08 44 PM](https://github.com/user-attachments/assets/a5b9bea9-48d3-4d59-a71a-634516831887)

if it's **approved** - workflow proceeds:
![Screenshot 2026-03-11 at 12 09 19 PM](https://github.com/user-attachments/assets/a64f1de1-1736-4378-96a0-9c5a708e1df6)