### PR TITLE
[Add] Ollama Quick Deploy App

### DIFF
--- a/apps/linode-marketplace-ollama/.ansible-lint
+++ b/apps/linode-marketplace-ollama/.ansible-lint
@@ -1,0 +1,10 @@
+---
+skip_list:
+  - command-instead-of-shell
+  - no-changed-when
+  - no-jinja-when
+  - fqcn-builtins
+exclude_paths:
+  - .cache/
+  - .github/
+  - tests/

--- a/apps/linode-marketplace-ollama/.yamllint
+++ b/apps/linode-marketplace-ollama/.yamllint
@@ -1,0 +1,38 @@
+---
+# Based on ansible-lint config
+extends: default
+
+ignore: |
+  .github/*
+  .cache/*
+  tests/*
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/apps/linode-marketplace-ollama/README.md
+++ b/apps/linode-marketplace-ollama/README.md
@@ -1,0 +1,125 @@
+# Akamai Cloud Compute - DeepSeek R1 and Open WebUI Deployment One-Click App
+
+Open WebUI is an open-source, self-hosted web interface for interacting with and managing large language models. It supports multiple AI backends, multi-user access, and extensible integrations, enabling secure and customizable deployment for local or remote model inference.
+
+Our Quick Deploy application deploys DeepSeek R1 distilled models (Qwen2.5-based) with vLLM as the inference backend and Open WebUI as the chat interface. These models are distilled from the full 671B DeepSeek-R1, providing enhanced chain-of-thought reasoning capabilities in smaller, deployable sizes.
+
+During deployment, you can choose between three model sizes to match your GPU capabilities and performance requirements. See **Resource Requirements** below.
+
+## Software Included
+
+| Software  | Version   | Description   |
+| :---      | :----     | :---          |
+| Docker    | `29.2.1`    | Container Management Runtime |
+| Docker Compose    | `v5.0.2`    | Tool for multi-container applications |
+| Nginx    | `1.24.0`    | HTTP server used to serve web applications |
+| vLLM | `v0.14.0` | Library to run LLM inference models  |
+| Open WebUI | `magin` tag | Self-hosted AI interface platform |
+
+**Supported Distributions:**
+
+- Ubuntu 24.04 LTS
+
+## Linode Helpers Included
+
+| Name | Description | Actions
+| :--- | :---        | :---
+| UFW   | Add UFW firewalls to the Linode  | The UFW module will import a `ufw_rules.yml` provided in `roles/common/tasks` and enables the service.  |
+| Certbot SSL   | Generates and sets auto-renew for Certbot SSL certificates  | The Certbot module installs Certbot Python plugin and certificates based on the webserver detected by Ansible. The default renewal cron runs Mondays at 00:00AM and can be manually edited. |
+| Fail2Ban   | Installs, activates and enables Fail2Ban  | The Fail2Ban module installs, activates and enables the Fail2Ban service.   |
+| Hostname   | Assigns a hostname to the Linode based on domains provided via UDF or uses default rDNS. | The Hostname module accepts a UDF to assign a FQDN and write to the `/etc/hosts` file. If no domain is provided the default `ip.linodeusercontent.com` rDNS will be used. For consistency, DNS and SSL configurations should use the Hostname generated `_domain` var when possible. |
+| Secure SSH   | Performs standard SSH hardening.  | The Secure SSH module writes to `/etc/ssh/sshd_config` to prevent password authentication and enable public key authentication for all users, including root.  |
+| Sudo User  | Creates limited `sudo` user with variable supplied username.  | Creates limited user from UDF supplied `username.` Note that usernames containing illegal characters will cause the play to fail. |
+| SSH Key   | Writes SSH pubkey to `sudo` user's `authorized_keys`.  | Writes UDF supplied `pubkey` to `/home/$username/.ssh/authorized_keys`. To add a SSH key to `root` please use [Cloud Manager SSH Keys](https://www.linode.com/docs/products/tools/cloud-manager/guides/manage-ssh-keys/).   |
+| Update Packages   | Performs standard apt updates and upgrades. | The Update Packages module performs apt update and upgrade actions as root.  |
+| GPU Utils | Detects GPU on the instance and install NVIDIA drivers | Writes `gpu_devices`, `gpu_count`, and `_has_gpu` to `group_vars/linode/vars` |
+
+# Architecture
+
+## Overview
+
+The DeepSeek R1 deployment consists of two containerized services that work together to provide a complete AI inference stack:
+
+1. **API Service** (`vLLM`): High-performance inference engine with tensor parallelism
+2. **UI Service** (`Open WebUI`): Feature-rich chat interface
+
+Both services are managed via Docker Compose and configured to restart automatically.
+
+## Containerized Services
+
+### API Service (vLLM)
+
+- **Port**: `localhost:8000`
+- **Container**: `vllm/vllm-openai:v0.14.0`
+- **Model**: `deepseek-ai/DeepSeek-R1-Distill-Qwen-7B`, `14B`, or `32B` (user selectable)
+- **Purpose**: High-performance inference engine with OpenAI-compatible REST API
+- **Features**:
+  - OpenAI-compatible REST API
+  - GPU-accelerated inference with automatic tensor parallelism (required for 14B and 32B models)
+  - MIT licensed models (no authentication required)
+  - Chain-of-thought reasoning with `<think>` traces
+  - 16,384 token context length
+
+### UI Service (Open WebUI)
+
+- **Port**: `localhost:3000`
+- **Container**: `ghcr.io/open-webui/open-webui:main`
+- **Purpose**: Browser-based chat interface
+- **Features**:
+  - Browser-based chat UI
+  - Persistent chat history
+  - Connected to the API service automatically
+  - User-friendly interface for interacting with models
+
+## Web Service
+
+### HTTPS (Nginx)
+
+- **port**: 443
+- **Features**:
+  - HTTPS Secured domain via Let's Encrypt
+
+## Directory Structure
+
+The following directories are used on the deployed instance:
+
+- `/opt/deepseek` - Application directory containing docker-compose.yml
+- `vllm_data` volume - Model cache directory (stores downloaded models)
+- `open_webui_data` volume - Chat UI persistent data (chat history, settings)
+
+## Service Communication
+
+The UI service automatically connects to the API service running on `localhost:8000`. Both services run on the same instance and communicate over the Docker network.
+
+## Tensor Parallelism
+
+The deployment automatically detects the number of available GPUs and configures vLLM to use tensor parallelism across all of them. This is required for the 14B and 32B models (which do not fit on a single GPU).
+
+## RAG Operations in Open WebUI
+
+Open WebUI provides built-in support for RAG operations allowing users to chat with their documents. This implementation uses Nginx as a frontend web service proxy to the Open WebUI container. Users that are looking to upload documents larger than 100MBs are required to update Nginx's `client_max_body_size` to a larger value.
+
+You can find the Nginx virtual host configuration in `/etc/nginx/sites-enabled/${DOMAIN}`. Where `${DOMAIN}` should reflect the rDNS of your compute instance.
+
+## Resource Requirements
+
+### For DeepSeek R1 Distill Qwen 7B
+- **GPU**: Any 1-GPU instance (RTX 4000 Ada or Quadro RTX 6000)
+- **RAM**: 16GB or higher
+- **Storage**: Sufficient space for model files (~14GB download)
+- **Compatible Plans**: All Ada 1-GPU plans, Quadro RTX 6000 1-GPU
+- **Reference**: [DeepSeek-R1-Distill-Qwen-7B on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B)
+
+### For DeepSeek R1 Distill Qwen 14B
+- **GPU**: Any 2-GPU instance or higher (RTX 4000 Ada or Quadro RTX 6000)
+- **RAM**: 32GB or higher
+- **Storage**: Sufficient space for model files (~28GB download)
+- **Compatible Plans**: All Ada 2-GPU and 4-GPU plans, Quadro RTX 6000 2-GPU, 3-GPU, and 4-GPU
+- **Reference**: [DeepSeek-R1-Distill-Qwen-14B on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B)
+
+### For DeepSeek R1 Distill Qwen 32B
+- **GPU**: Any 4-GPU instance (RTX 4000 Ada or Quadro RTX 6000)
+- **RAM**: 128GB or higher
+- **Storage**: Sufficient space for model files (~64GB download)
+- **Compatible Plans**: Ada 4-GPU plans, Quadro RTX 6000 4-GPU
+- **Reference**: [DeepSeek-R1-Distill-Qwen-32B on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B)

--- a/apps/linode-marketplace-ollama/README.md
+++ b/apps/linode-marketplace-ollama/README.md
@@ -1,8 +1,8 @@
-# Akamai Cloud Compute - DeepSeek R1 and Open WebUI Deployment One-Click App
+# Akamai Cloud Compute - Ollama and Open WebUI Deployment One-Click App
 
 Open WebUI is an open-source, self-hosted web interface for interacting with and managing large language models. It supports multiple AI backends, multi-user access, and extensible integrations, enabling secure and customizable deployment for local or remote model inference.
 
-Our Quick Deploy application deploys DeepSeek R1 distilled models (Qwen2.5-based) with vLLM as the inference backend and Open WebUI as the chat interface. These models are distilled from the full 671B DeepSeek-R1, providing enhanced chain-of-thought reasoning capabilities in smaller, deployable sizes.
+Our Quick Deploy application sets up Ollama as the inference backend paired with Open WebUI as the chat interface. Ollama makes it simple to pull and run a wide range of open-source large language models locally, with full GPU acceleration and no external API dependencies required.
 
 During deployment, you can choose between three model sizes to match your GPU capabilities and performance requirements. See **Resource Requirements** below.
 
@@ -10,11 +10,11 @@ During deployment, you can choose between three model sizes to match your GPU ca
 
 | Software  | Version   | Description   |
 | :---      | :----     | :---          |
-| Docker    | `29.2.1`    | Container Management Runtime |
+| Docker    | `29.4.0`    | Container Management Runtime |
 | Docker Compose    | `v5.0.2`    | Tool for multi-container applications |
 | Nginx    | `1.24.0`    | HTTP server used to serve web applications |
-| vLLM | `v0.14.0` | Library to run LLM inference models  |
-| Open WebUI | `magin` tag | Self-hosted AI interface platform |
+| Ollama | `latest` | Local LLM inference engine with GPU support |
+| Open WebUI | `main` tag | Self-hosted AI interface platform |
 
 **Supported Distributions:**
 
@@ -36,90 +36,120 @@ During deployment, you can choose between three model sizes to match your GPU ca
 
 # Architecture
 
-## Overview
+### Overview
 
-The DeepSeek R1 deployment consists of two containerized services that work together to provide a complete AI inference stack:
+The deployment consists of two containerized services that work together to provide a complete AI inference stack:
 
-1. **API Service** (`vLLM`): High-performance inference engine with tensor parallelism
-2. **UI Service** (`Open WebUI`): Feature-rich chat interface
+1. **Ollama**: Local LLM inference engine with GPU acceleration
+2. **Open WebUI**: Feature-rich browser-based chat interface
 
-Both services are managed via Docker Compose and configured to restart automatically.
+Both services are managed via Docker Compose and configured to restart automatically (`unless-stopped`).
+
+---
 
 ## Containerized Services
 
-### API Service (vLLM)
+### Ollama (LLM Engine)
 
-- **Port**: `localhost:8000`
-- **Container**: `vllm/vllm-openai:v0.14.0`
-- **Model**: `deepseek-ai/DeepSeek-R1-Distill-Qwen-7B`, `14B`, or `32B` (user selectable)
-- **Purpose**: High-performance inference engine with OpenAI-compatible REST API
+- **Port**: `localhost:11434`
+- **Container**: `ollama/ollama:latest`
+- **Purpose**: Local inference engine with a REST API compatible with OpenAI-style clients
 - **Features**:
-  - OpenAI-compatible REST API
-  - GPU-accelerated inference with automatic tensor parallelism (required for 14B and 32B models)
-  - MIT licensed models (no authentication required)
-  - Chain-of-thought reasoning with `<think>` traces
-  - 16,384 token context length
+  - GPU-accelerated inference using all available NVIDIA GPUs
+  - Supports a wide range of open models (Llama, Mistral, Gemma, Qwen, DeepSeek, etc.)
+  - Model persistence via Docker volume
+  - Health check via `ollama list`
 
-### UI Service (Open WebUI)
+### Open WebUI (Chat Interface)
 
 - **Port**: `localhost:3000`
 - **Container**: `ghcr.io/open-webui/open-webui:main`
-- **Purpose**: Browser-based chat interface
+- **Purpose**: Browser-based chat interface connected to Ollama
 - **Features**:
   - Browser-based chat UI
   - Persistent chat history
-  - Connected to the API service automatically
-  - User-friendly interface for interacting with models
+  - Automatically connects to Ollama at `http://ollama:11434`
+  - Multi-user support
+  - Telemetry disabled by default (`ANONYMIZED_TELEMETRY=false`)
 
-## Web Service
-
-### HTTPS (Nginx)
-
-- **port**: 443
-- **Features**:
-  - HTTPS Secured domain via Let's Encrypt
+---
 
 ## Directory Structure
 
-The following directories are used on the deployed instance:
+The following Docker volumes are used:
 
-- `/opt/deepseek` - Application directory containing docker-compose.yml
-- `vllm_data` volume - Model cache directory (stores downloaded models)
-- `open_webui_data` volume - Chat UI persistent data (chat history, settings)
+- `ollama_data` — Stores downloaded models and Ollama configuration (`/root/.ollama`)
+- `open_webui_data` — Stores chat history, user settings, and UI data (`/app/backend/data`)
+
+---
 
 ## Service Communication
 
-The UI service automatically connects to the API service running on `localhost:8000`. Both services run on the same instance and communicate over the Docker network.
+Open WebUI connects to Ollama over the internal Docker network using the service name as the hostname (`http://ollama:11434`). Both services run on the same host and communicate without exposing Ollama publicly.
 
-## Tensor Parallelism
+---
 
-The deployment automatically detects the number of available GPUs and configures vLLM to use tensor parallelism across all of them. This is required for the 14B and 32B models (which do not fit on a single GPU).
+## Adding New Models
 
-## RAG Operations in Open WebUI
+To pull and run a new model, use `docker exec` to interact with the running Ollama container.
 
-Open WebUI provides built-in support for RAG operations allowing users to chat with their documents. This implementation uses Nginx as a frontend web service proxy to the Open WebUI container. Users that are looking to upload documents larger than 100MBs are required to update Nginx's `client_max_body_size` to a larger value.
+### Pull a model
 
-You can find the Nginx virtual host configuration in `/etc/nginx/sites-enabled/${DOMAIN}`. Where `${DOMAIN}` should reflect the rDNS of your compute instance.
+```bash
+docker exec ollama ollama pull 
+```
+
+**Examples:**
+
+```bash
+# Pull Llama 3.2 (3B)
+docker exec ollama ollama pull llama3.2
+
+# Pull Mistral 7B
+docker exec ollama ollama pull mistral
+
+# Pull DeepSeek R1 (7B)
+docker exec ollama ollama pull deepseek-r1:7b
+
+# Pull Gemma 3 (4B)
+docker exec ollama ollama pull gemma3:4b
+
+# Pull Qwen 2.5 (7B)
+docker exec ollama ollama pull qwen2.5:7b
+```
+
+Browse the full model library at [ollama.com/library](https://ollama.com/library).
+
+### List downloaded models
+
+```bash
+docker exec ollama ollama list
+```
+
+### Remove a model
+
+```bash
+docker exec ollama ollama rm 
+```
+
+### Run a model directly in the terminal (optional)
+
+```bash
+docker exec -it ollama ollama run 
+```
+
+Once pulled, models will automatically appear in the Open WebUI model selector — no restart required.
+
+---
 
 ## Resource Requirements
 
-### For DeepSeek R1 Distill Qwen 7B
-- **GPU**: Any 1-GPU instance (RTX 4000 Ada or Quadro RTX 6000)
-- **RAM**: 16GB or higher
-- **Storage**: Sufficient space for model files (~14GB download)
-- **Compatible Plans**: All Ada 1-GPU plans, Quadro RTX 6000 1-GPU
-- **Reference**: [DeepSeek-R1-Distill-Qwen-7B on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B)
+GPU resources are reserved automatically for all available NVIDIA devices. Requirements will vary depending on the model you choose to run.
 
-### For DeepSeek R1 Distill Qwen 14B
-- **GPU**: Any 2-GPU instance or higher (RTX 4000 Ada or Quadro RTX 6000)
-- **RAM**: 32GB or higher
-- **Storage**: Sufficient space for model files (~28GB download)
-- **Compatible Plans**: All Ada 2-GPU and 4-GPU plans, Quadro RTX 6000 2-GPU, 3-GPU, and 4-GPU
-- **Reference**: [DeepSeek-R1-Distill-Qwen-14B on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B)
+| Model Size | VRAM Required | Example Models |
+| :--- | :--- | :--- |
+| 3B–7B | 6–8GB VRAM | Llama 3.2 3B, Mistral 7B, DeepSeek R1 7B |
+| 8B–14B | 10–16GB VRAM | Llama 3.1 8B, DeepSeek R1 14B, Gemma 3 12B |
+| 32B+ | 24GB+ VRAM | DeepSeek R1 32B, Qwen 2.5 32B |
 
-### For DeepSeek R1 Distill Qwen 32B
-- **GPU**: Any 4-GPU instance (RTX 4000 Ada or Quadro RTX 6000)
-- **RAM**: 128GB or higher
-- **Storage**: Sufficient space for model files (~64GB download)
-- **Compatible Plans**: Ada 4-GPU plans, Quadro RTX 6000 4-GPU
-- **Reference**: [DeepSeek-R1-Distill-Qwen-32B on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B)
+For multi-GPU setups, Ollama will automatically use all available GPUs as configured in the Compose file (`count: all`).Sonnet 4.6Claude is AI and can make mistakes. Please double-

--- a/apps/linode-marketplace-ollama/ansible.cfg
+++ b/apps/linode-marketplace-ollama/ansible.cfg
@@ -1,0 +1,7 @@
+[defaults]
+host_key_checking = False
+enable_plugins = linode
+deprecation_warnings = False
+interpreter_python = /usr/bin/python3
+roles_path=./roles:../linode_helpers/roles
+# relative or absolute roles_paths are required.

--- a/apps/linode-marketplace-ollama/collections.yml
+++ b/apps/linode-marketplace-ollama/collections.yml
@@ -1,0 +1,10 @@
+---
+collections:
+  - name: linode.cloud
+    version: 0.41.1
+  - name: community.crypto
+    version: 3.0.5
+  - name: community.docker
+    version: 5.0.0
+  - name: community.general
+    version: 11.4.1

--- a/apps/linode-marketplace-ollama/provision.yml
+++ b/apps/linode-marketplace-ollama/provision.yml
@@ -1,0 +1,25 @@
+---
+# linode ansible playbook
+
+- name: Setting up environment
+  hosts: localhost
+  connection: local
+  any_errors_fatal: true
+  user: root
+  vars_files: [group_vars/linode/vars]
+  tasks:
+
+    - name: Ensure instance has GPU before continuing
+      import_tasks: ../linode_helpers/roles/gpu_utils/tasks/main.yml
+      vars:
+        gpu_required: true
+
+    - name: Generating sudo user and password
+      import_tasks: ../linode_helpers/roles/sudouser/tasks/main.yml
+
+    - name: Generating Open WebUI password
+      blockinfile:
+        insertafter: EOF
+        path: group_vars/linode/vars
+        block: |
+          openwebui_login_password: {{ lookup('password', '/dev/null length=45 chars=ascii_letters,digits') }}

--- a/apps/linode-marketplace-ollama/requirements.txt
+++ b/apps/linode-marketplace-ollama/requirements.txt
@@ -1,0 +1,11 @@
+ansible==13.5.0
+yamllint==1.38.0
+ansible-lint==26.3.0
+flake8==7.3.0
+linode_api4==5.42.0
+dnspython==2.8.0
+polling==0.3.2
+ansible-specdoc==0.0.20
+pyyaml==6.0.3
+pexpect==4.9.0
+passlib==1.7.4

--- a/apps/linode-marketplace-ollama/roles/common/tasks/main.yml
+++ b/apps/linode-marketplace-ollama/roles/common/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: Setting up hostname
+  import_role:
+    name: hostname
+
+- name: Set ssh pubkey
+  import_role:
+    name: sshkey
+
+- name: Create dns A record
+  import_role:
+    name: create_dns_record
+  when: [token_password is defined, default_dns is not defined]
+
+- name: Secure ssh
+  import_role:
+    name: securessh
+  when: disable_root is defined
+
+- name: Update system packages
+  import_role:
+    name: update_pkgs
+
+- name: Enabling ufw
+  import_role:
+    name: ufw
+
+- name: Apply ufw rules
+  import_tasks: ufw_rules.yml
+
+- name: Enabling fail2ban
+  import_role:
+    name: fail2ban_install

--- a/apps/linode-marketplace-ollama/roles/common/tasks/ufw_rules.yml
+++ b/apps/linode-marketplace-ollama/roles/common/tasks/ufw_rules.yml
@@ -1,0 +1,19 @@
+---
+# set app specific ufw rules
+- name: Allow all access to tcp port 22
+  community.general.ufw:
+    rule: allow
+    port: '22'
+    proto: tcp
+
+- name: Allow all access to HTTP
+  community.general.ufw:
+    rule: allow
+    port: '80'
+    proto: tcp
+
+- name: Allow all access to HTTPS
+  community.general.ufw:
+    rule: allow
+    port: '443'
+    proto: tcp

--- a/apps/linode-marketplace-ollama/roles/ollama/defaults/main.yml
+++ b/apps/linode-marketplace-ollama/roles/ollama/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+docker_directory: '/opt/ollama'

--- a/apps/linode-marketplace-ollama/roles/ollama/handlers/main.yml
+++ b/apps/linode-marketplace-ollama/roles/ollama/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart nginx
+  systemd_service:
+    name: nginx
+    state: restarted

--- a/apps/linode-marketplace-ollama/roles/ollama/tasks/containers.yml
+++ b/apps/linode-marketplace-ollama/roles/ollama/tasks/containers.yml
@@ -43,3 +43,29 @@
   until: ollama_health.status == 200
   retries: 60
   delay: 10
+
+- name: Validate and install Ollama model
+  block:
+    - name: Validate model against Ollama registry
+      community.docker.docker_container_exec:
+        container: ollama
+        command: "ollama show {{ llm }}"
+      register: ollama_validate
+      failed_when: ollama_validate.rc != 0
+
+    - name: Pull Ollama model
+      community.docker.docker_container_exec:
+        container: ollama
+        command: "ollama pull {{ llm }}"
+      timeout: 600
+
+  rescue:
+    - name: Report invalid or unavailable model
+      fail:
+        msg: |
+          Deployment halted: The specified language model '{{ llm }}' could not be
+          validated against the Ollama model registry.
+
+          Please verify the model name is correct and available at https://ollama.com/library
+          before retrying the deployment.
+  when: llm is defined

--- a/apps/linode-marketplace-ollama/roles/ollama/tasks/containers.yml
+++ b/apps/linode-marketplace-ollama/roles/ollama/tasks/containers.yml
@@ -45,6 +45,7 @@
   delay: 10
 
 - name: Validate and install Ollama model
+  when: llm is defined
   block:
     - name: Pull Ollama model
       community.docker.docker_container_exec:
@@ -63,4 +64,4 @@
 
           Please verify the model name is correct and available at https://ollama.com/library
           before retrying the deployment.
-  when: llm is defined
+  

--- a/apps/linode-marketplace-ollama/roles/ollama/tasks/containers.yml
+++ b/apps/linode-marketplace-ollama/roles/ollama/tasks/containers.yml
@@ -46,25 +46,20 @@
 
 - name: Validate and install Ollama model
   block:
-    - name: Validate model against Ollama registry
-      community.docker.docker_container_exec:
-        container: ollama
-        command: "ollama show {{ llm }}"
-      register: ollama_validate
-      failed_when: ollama_validate.rc != 0
-
     - name: Pull Ollama model
       community.docker.docker_container_exec:
         container: ollama
         command: "ollama pull {{ llm }}"
       timeout: 600
+      register: ollama_pull
+      failed_when: ollama_pull.rc != 0
 
   rescue:
     - name: Report invalid or unavailable model
       fail:
         msg: |
           Deployment halted: The specified language model '{{ llm }}' could not be
-          validated against the Ollama model registry.
+          pulled from the Ollama model registry.
 
           Please verify the model name is correct and available at https://ollama.com/library
           before retrying the deployment.

--- a/apps/linode-marketplace-ollama/roles/ollama/tasks/containers.yml
+++ b/apps/linode-marketplace-ollama/roles/ollama/tasks/containers.yml
@@ -1,0 +1,45 @@
+---
+- name: Install Docker latest
+  import_role:
+    name: docker
+
+- name: Installing docker-compose
+  apt:
+    pkg: [docker-compose]
+    state: present
+
+- name: Set tensor parallel size
+  set_fact:
+    tensor_parallel_size: "{{ gpu_count | default(1) }}"
+
+- name: Create docker directory
+  file:
+    path: "{{ docker_directory }}"
+    state: directory
+    mode: '0755'
+
+- name: Template docker-compose file
+  template:
+    src: docker-compose.yml.j2
+    dest: "{{ docker_directory }}/docker-compose.yml"
+    mode: '0644'
+
+- name: Pull Docker images from compose file
+  community.docker.docker_compose_v2:
+    project_src: "{{ docker_directory }}"
+    pull: always
+
+- name: Start containers from docker-compose file
+  community.docker.docker_compose_v2:
+    project_src: "{{ docker_directory }}"
+    state: present
+
+- name: Wait for Ollama service to start
+  uri:
+    url: "http://localhost:11434/api/tags"
+    method: GET
+    status_code: [200]
+  register: ollama_health
+  until: ollama_health.status == 200
+  retries: 60
+  delay: 10

--- a/apps/linode-marketplace-ollama/roles/ollama/tasks/containers.yml
+++ b/apps/linode-marketplace-ollama/roles/ollama/tasks/containers.yml
@@ -64,4 +64,3 @@
 
           Please verify the model name is correct and available at https://ollama.com/library
           before retrying the deployment.
-  

--- a/apps/linode-marketplace-ollama/roles/ollama/tasks/drivers.yml
+++ b/apps/linode-marketplace-ollama/roles/ollama/tasks/drivers.yml
@@ -1,0 +1,7 @@
+---
+- name: Install NVIDIA drivers
+  import_role:
+    name: gpu_utils
+  vars:
+    install_nvidia: true
+    docker_gpu_enable: true

--- a/apps/linode-marketplace-ollama/roles/ollama/tasks/main.yml
+++ b/apps/linode-marketplace-ollama/roles/ollama/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Install NVIDIA drivers
+  import_tasks: drivers.yml
+
+- name: Install Docker and container components
+  import_tasks: containers.yml
+
+- name: Configure Open WebUI initial admin account
+  import_role:
+    name: open_webui
+  when: openwebui_enabled == "yes"
+
+- name: Configure Nginx and SSL certificates
+  import_tasks: nginx.yml
+  when: openwebui_enabled == "yes"

--- a/apps/linode-marketplace-ollama/roles/ollama/tasks/main.yml
+++ b/apps/linode-marketplace-ollama/roles/ollama/tasks/main.yml
@@ -8,8 +8,6 @@
 - name: Configure Open WebUI initial admin account
   import_role:
     name: open_webui
-  when: openwebui_enabled == "yes"
 
 - name: Configure Nginx and SSL certificates
   import_tasks: nginx.yml
-  when: openwebui_enabled == "yes"

--- a/apps/linode-marketplace-ollama/roles/ollama/tasks/nginx.yml
+++ b/apps/linode-marketplace-ollama/roles/ollama/tasks/nginx.yml
@@ -1,0 +1,36 @@
+---
+- name: Install Nginx
+  apt:
+    name: nginx
+    state: present
+    update_cache: true
+
+- name: Create Nginx vhost configuration
+  template:
+    src: nginx.conf.j2
+    dest: /etc/nginx/sites-available/{{ _domain }}
+    mode: '0644'
+
+- name: Enable vhost for {{ _domain }}
+  file:
+    src: /etc/nginx/sites-available/{{ _domain }}
+    dest: /etc/nginx/sites-enabled/{{ _domain }}
+    state: link
+
+- name: Disable Nginx default vhost
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+
+- name: Enable and start Nginx
+  systemd_service:
+    name: nginx
+    state: started
+    enabled: true
+
+- name: Install SSL certificate
+  import_role:
+    name: certbot_ssl
+  vars:
+    webserver_stack: lemp
+  notify: Restart nginx

--- a/apps/linode-marketplace-ollama/roles/ollama/templates/docker-compose.yml.j2
+++ b/apps/linode-marketplace-ollama/roles/ollama/templates/docker-compose.yml.j2
@@ -39,8 +39,6 @@ services:
       - open_webui_data:/app/backend/data
     environment:
       - OLLAMA_BASE_URL=http://ollama:11434
-      - WEBUI_AUTH=true
-      - ENABLE_SIGNUP=false
       - ANONYMIZED_TELEMETRY=false
     depends_on:
       ollama:

--- a/apps/linode-marketplace-ollama/roles/ollama/templates/docker-compose.yml.j2
+++ b/apps/linode-marketplace-ollama/roles/ollama/templates/docker-compose.yml.j2
@@ -1,0 +1,55 @@
+services:
+  #--------------------------------------------
+  # Ollama - The LLM Engine
+  #--------------------------------------------
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    environment:
+      - OLLAMA_KEEP_ALIVE=24h
+      - OLLAMA_NUM_PARALLEL=4
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+{% if openwebui_enabled == "yes" %}
+  #--------------------------------------------
+  # Open-WebUI - The User Interface
+  #--------------------------------------------
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: open-webui
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3000:8080"
+    volumes:
+      - open_webui_data:/app/backend/data
+    environment:
+      - OLLAMA_BASE_URL=http://ollama:11434
+      - WEBUI_AUTH=true
+      - ENABLE_SIGNUP=false
+      - ANONYMIZED_TELEMETRY=false
+    depends_on:
+      ollama:
+        condition: service_started
+{% endif %}
+
+volumes:
+  ollama_data:
+{% if openwebui_enabled == "yes" %}
+  open_webui_data:
+{% endif %}

--- a/apps/linode-marketplace-ollama/roles/ollama/templates/docker-compose.yml.j2
+++ b/apps/linode-marketplace-ollama/roles/ollama/templates/docker-compose.yml.j2
@@ -26,7 +26,6 @@ services:
       timeout: 5s
       retries: 5
 
-{% if openwebui_enabled == "yes" %}
   #--------------------------------------------
   # Open-WebUI - The User Interface
   #--------------------------------------------
@@ -46,10 +45,7 @@ services:
     depends_on:
       ollama:
         condition: service_started
-{% endif %}
 
 volumes:
   ollama_data:
-{% if openwebui_enabled == "yes" %}
   open_webui_data:
-{% endif %}

--- a/apps/linode-marketplace-ollama/roles/ollama/templates/nginx.conf.j2
+++ b/apps/linode-marketplace-ollama/roles/ollama/templates/nginx.conf.j2
@@ -1,0 +1,30 @@
+upstream open-webui {
+    server 127.0.0.1:3000;
+}
+
+server {
+    listen 80;
+    server_name {{ _domain }};
+
+    location / {
+        proxy_pass http://open-webui;
+
+        # Set necessary headers
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Enable WebSocket connections
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        # Extend timeouts for long AI model responses or downloads
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 36000s;
+
+        # Allows large documents to be uploaded to Open WebUI
+        client_max_body_size 100M;
+    }
+}

--- a/apps/linode-marketplace-ollama/roles/post/tasks/main.yml
+++ b/apps/linode-marketplace-ollama/roles/post/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# Install Addons if requested
+- name: Add addons
+  import_role:
+    name: addons
+  when: add_ons != ['none']
+
+# motd and creds gen
+- name: Copy MOTD template to /etc/motd
+  template:
+    src: templates/motd.j2
+    dest: /etc/motd
+    mode: '0600'
+    owner: '{{ username }}'
+    group: '{{ username }}'
+
+- name: Writing sudo creds into file
+  copy:
+    dest: '/home/{{ username }}/.credentials'
+    mode: '0600'
+    owner: '{{ username }}'
+    group: '{{ username }}'
+    content: |
+      Sudo Username: {{ username }}
+      Sudo Password: {{ password }}
+      Open WebUI admin name: {{ openwebui_login_name }}
+      Open WebUI admin email: {{ openwebui_login_email }}
+      Open WebUI admin password: {{ openwebui_login_password }}

--- a/apps/linode-marketplace-ollama/roles/post/templates/motd.j2
+++ b/apps/linode-marketplace-ollama/roles/post/templates/motd.j2
@@ -1,0 +1,11 @@
+*********************************************************
+Akamai Connected Cloud - Ollama
+{% if openwebui_enabled == "yes" %}
+App URL: https://{{ _domain }}
+{% else %}
+Ollama API Endpoint: http://localhost:11434
+{% endif %}
+Credentials File: /home/{{ username }}/.credentials
+Documentation: https://www.linode.com/marketplace/apps/linode/ollama/
+*********************************************************
+To delete this message of the day: rm /etc/motd

--- a/apps/linode-marketplace-ollama/roles/post/templates/motd.j2
+++ b/apps/linode-marketplace-ollama/roles/post/templates/motd.j2
@@ -1,7 +1,6 @@
 *********************************************************
 Akamai Connected Cloud - Ollama
 App URL: https://{{ _domain }}
-Ollama API Endpoint: http://localhost:11434
 Credentials File: /home/{{ username }}/.credentials
 Documentation: https://www.linode.com/marketplace/apps/linode/ollama/
 *********************************************************

--- a/apps/linode-marketplace-ollama/roles/post/templates/motd.j2
+++ b/apps/linode-marketplace-ollama/roles/post/templates/motd.j2
@@ -1,10 +1,7 @@
 *********************************************************
 Akamai Connected Cloud - Ollama
-{% if openwebui_enabled == "yes" %}
 App URL: https://{{ _domain }}
-{% else %}
 Ollama API Endpoint: http://localhost:11434
-{% endif %}
 Credentials File: /home/{{ username }}/.credentials
 Documentation: https://www.linode.com/marketplace/apps/linode/ollama/
 *********************************************************

--- a/apps/linode-marketplace-ollama/site.yml
+++ b/apps/linode-marketplace-ollama/site.yml
@@ -1,0 +1,33 @@
+---
+# linode ansible playbook
+
+- name: Ollama with Open Webui setup
+  hosts: localhost
+  connection: local
+  any_errors_fatal: true
+  user: root
+  vars_files: [group_vars/linode/vars]
+
+  tasks:
+    - name: Running in staging mode
+      when: "mode == 'staging'"
+      block:
+        - name: Run roles
+          include_role:
+            name: "{{ item }}"
+          loop: [common, ollama, post]
+        - name: Deployment passed
+          import_tasks: ../linode_helpers/roles/cilog/tasks/main.yml
+          vars:
+            deploy_status: 'successful'
+      rescue:
+        - name: Deployment failed
+          import_tasks: ../linode_helpers/roles/cilog/tasks/main.yml
+          vars:
+            deploy_status: 'failed'
+
+    - name: Running app normally
+      include_role:
+        name: "{{ item }}"
+      loop: [common, ollama, post]
+      when: "mode == 'production'"

--- a/deployment_scripts/linode-marketplace-ollama/linode-config.sh
+++ b/deployment_scripts/linode-marketplace-ollama/linode-config.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REGION="us-ord"
+LINODE_TYPE="g2-gpu-rtx4000a1-s"
+IMAGE="linode/ubuntu24.04"
+
+echo "REGION=${REGION}" >> "$GITHUB_ENV"
+echo "LINODE_TYPE=${LINODE_TYPE}" >> "$GITHUB_ENV"
+echo "IMAGE=${IMAGE}" >> "$GITHUB_ENV"

--- a/deployment_scripts/linode-marketplace-ollama/ollama-deploy.sh
+++ b/deployment_scripts/linode-marketplace-ollama/ollama-deploy.sh
@@ -99,7 +99,6 @@ function udf {
   # open webui admin credentials
   openwebui_login_name: ${OPENWEBUI_LOGIN_NAME}
   openwebui_login_email: ${OPENWEBUI_LOGIN_EMAIL}
-  llm: $(echo -e "${LLM}")
 
   # BEGIN CI-UDF-ADDONS
   # addons
@@ -107,6 +106,11 @@ function udf {
   # END CI-UDF-ADDONS
 
 EOF
+
+  if [[ -n ${LLM} ]]; then
+    echo "llm: ${LLM}" >> ${group_vars};
+  else echo "No LLM entered";
+  fi
 
   if [ "$DISABLE_ROOT" = "Yes" ]; then
     echo "disable_root: true" >> ${group_vars};

--- a/deployment_scripts/linode-marketplace-ollama/ollama-deploy.sh
+++ b/deployment_scripts/linode-marketplace-ollama/ollama-deploy.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+
+# enable logging
+exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
+
+# BEGIN CI-MODE
+# modes
+#DEBUG="NO"
+if [[ -n ${DEBUG} ]]; then
+  if [ "${DEBUG}" == "NO" ]; then
+    trap "cleanup $? $LINENO" EXIT
+  fi
+else
+  trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
+fi
+# END CI-MODE
+
+## Linode/SSH security settings
+#<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">
+#<UDF name="disable_root" label="Disable root access over SSH?" oneOf="Yes,No" default="No">
+
+## Domain Settings
+#<UDF name="token_password" label="Your Linode API token. This is needed to create your server's DNS records" default="">
+#<UDF name="subdomain" label="Subdomain" example="The subdomain for the DNS record: www (Requires Domain)" default="">
+#<UDF name="domain" label="Domain" example="The domain for the DNS record: example.com (Requires API token)" default="">
+#<UDF name="soa_email_address" label="Email address (for the Let's Encrypt SSL certificate)" example="user@domain.tld (Requires API token)">
+
+# BEGIN CI-ADDONS
+## Addons
+#<UDF name="add_ons" label="Optional data exporter Add-ons for your deployment" manyOf="node_exporter,mysqld_exporter,newrelic,alloy,none" default="none">
+# END CI-ADDONS
+
+## Ollama Configuration
+#<UDF name="openwebui_login_name" label="The initial admin login name for Open WebUI">
+#<UDF name="openwebui_login_email" label="Email address for Open WebUI admin account">
+#<UDF name="openwebui_enabled" label="Would you like to enable openwebio" oneOf="Yes,No" default="Yes">
+
+#GH_USER=""
+#BRANCH=""
+# git user and branch
+if [[ -n ${GH_USER} && -n ${BRANCH} ]]; then
+        echo "[info] git user and branch set.."
+        export GIT_REPO="https://github.com/${GH_USER}/marketplace-apps.git"
+
+else
+        export GH_USER="akamai-compute-marketplace"
+        export BRANCH="main"
+        export GIT_REPO="https://github.com/${GH_USER}/marketplace-apps.git"
+fi
+
+export WORK_DIR="/tmp/marketplace-apps"
+export MARKETPLACE_APP="apps/linode-marketplace-ollama"
+
+function provision_failed {
+  echo "[info] Provision failed. Sending status.."
+
+  # dep
+  apt install jq -y
+
+  # set token
+  local token=($(curl -ks -X POST ${KC_SERVER} \
+     -H "Content-Type: application/json" \
+     -d "{ \"username\":\"${KC_USERNAME}\", \"password\":\"${KC_PASSWORD}\" }" | jq -r .token) )
+
+  # send pre-provision failure
+  curl -sk -X POST ${DATA_ENDPOINT} \
+     -H "Authorization: ${token}" \
+     -H "Content-Type: application/json" \
+     -d "{ \"app_label\":\"${APP_LABEL}\", \"status\":\"provision_failed\", \"branch\": \"${BRANCH}\", \
+        \"gituser\": \"${GH_USER}\", \"runjob\": \"${RUNJOB}\", \"image\":\"${IMAGE}\", \
+        \"type\":\"${TYPE}\", \"region\":\"${REGION}\", \"instance_env\":\"${INSTANCE_ENV}\" }"
+
+  exit $?
+}
+
+function cleanup {
+  if [ -d "${WORK_DIR}" ]; then
+    rm -rf ${WORK_DIR}
+  fi
+}
+
+function udf {
+  local group_vars="${WORK_DIR}/${MARKETPLACE_APP}/group_vars/linode/vars"
+  sed 's/  //g' <<EOF > ${group_vars}
+  # sudo username
+  username: ${USER_NAME}
+
+  # open webui admin credentials
+  openwebui_login_name: ${OPENWEBUI_LOGIN_NAME}
+  openwebui_login_email: ${OPENWEBUI_LOGIN_EMAIL}
+  openwebui_enabled: ${OPENWEBUI_ENABLED}
+
+  # BEGIN CI-UDF-ADDONS
+  # addons
+  add_ons: [${ADD_ONS}]
+  # END CI-UDF-ADDONS
+EOF
+
+  if [ "$DISABLE_ROOT" = "Yes" ]; then
+    echo "disable_root: true" >> ${group_vars};
+  else echo "Leaving root login enabled";
+  fi
+
+  if [[ -n ${DOMAIN} ]]; then
+    echo "domain: ${DOMAIN}" >> ${group_vars};
+  else
+    echo "default_dns: $(hostname -I | awk '{print $1}'| tr '.' '-' | awk {'print $1 ".ip.linodeusercontent.com"'})" >> ${group_vars};
+  fi
+
+  if [[ -n ${SUBDOMAIN} ]]; then
+    echo "subdomain: ${SUBDOMAIN}" >> ${group_vars};
+  else echo "subdomain: www" >> ${group_vars};
+  fi
+
+  if [[ -n ${TOKEN_PASSWORD} ]]; then
+    echo "token_password: ${TOKEN_PASSWORD}" >> ${group_vars};
+  else echo "No API token entered";
+  fi
+
+  if [[ -n ${SOA_EMAIL_ADDRESS} ]]; then
+    echo "soa_email_address: ${SOA_EMAIL_ADDRESS}" >> ${group_vars};
+  fi
+
+  # staging or production mode (ci)
+  if [[ "${MODE}" == "staging" ]]; then
+    echo "[info] running in staging mode..."
+    echo "mode: ${MODE}" >> ${group_vars}
+  else
+    echo "[info] running in production mode..."
+    echo "mode: production" >> ${group_vars}
+  fi
+}
+
+function run {
+  # install dependencies
+  apt-get update
+  apt-get install -y git python3 python3-pip
+
+  # clone repo and set up ansible environment
+  git -C /tmp clone -b ${BRANCH} ${GIT_REPO}
+
+  # set up python virtual environment
+  cd ${WORK_DIR}/${MARKETPLACE_APP}
+  apt install python3-venv -y
+  python3 -m venv env
+  source env/bin/activate
+  pip install pip --upgrade
+  pip install -r requirements.txt
+  ansible-galaxy install -r collections.yml
+
+  # populate group_vars
+  udf
+  # run playbooks
+  ansible-playbook -v provision.yml && ansible-playbook -v site.yml
+}
+
+function installation_complete {
+  echo "Installation Complete"
+}
+
+# main
+run
+installation_complete

--- a/deployment_scripts/linode-marketplace-ollama/ollama-deploy.sh
+++ b/deployment_scripts/linode-marketplace-ollama/ollama-deploy.sh
@@ -99,8 +99,7 @@ function udf {
   # open webui admin credentials
   openwebui_login_name: ${OPENWEBUI_LOGIN_NAME}
   openwebui_login_email: ${OPENWEBUI_LOGIN_EMAIL}
-  llm:
-$(echo -e "${LLM}")
+  llm: $(echo -e "${LLM}")
 
   # BEGIN CI-UDF-ADDONS
   # addons

--- a/deployment_scripts/linode-marketplace-ollama/ollama-deploy.sh
+++ b/deployment_scripts/linode-marketplace-ollama/ollama-deploy.sh
@@ -43,7 +43,8 @@ fi
 ## Ollama Configuration
 #<UDF name="openwebui_login_name" label="The initial admin login name for Open WebUI">
 #<UDF name="openwebui_login_email" label="Email address for Open WebUI admin account">
-#<UDF name="openwebui_enabled" label="Would you like to enable openwebio" oneOf="Yes,No" default="Yes">
+
+#<UDF name="llm" label="Ollama Model (e.g. llama3.2:3b, qwen2.5:7b, mistral:7b)" example="llama3.2:3b">
 
 #GH_USER=""
 #BRANCH=""
@@ -98,12 +99,14 @@ function udf {
   # open webui admin credentials
   openwebui_login_name: ${OPENWEBUI_LOGIN_NAME}
   openwebui_login_email: ${OPENWEBUI_LOGIN_EMAIL}
-  openwebui_enabled: ${OPENWEBUI_ENABLED}
+  llm:
+$(echo -e "${LLM}")
 
   # BEGIN CI-UDF-ADDONS
   # addons
   add_ons: [${ADD_ONS}]
   # END CI-UDF-ADDONS
+
 EOF
 
   if [ "$DISABLE_ROOT" = "Yes" ]; then

--- a/deployment_scripts/linode-marketplace-ollama/test-vars.sh
+++ b/deployment_scripts/linode-marketplace-ollama/test-vars.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+DEFAULT_DNS="$(hostname -I | awk '{print $1}'| tr '.' '-' | awk {'print $1 ".ip.linodeusercontent.com"'})"
+
+# custom env variables from cli
+if [[ -n ${INSTANCE_ENV} ]]; then
+  custom_vars=(${INSTANCE_ENV})
+  var_count=${#custom_vars[@]}
+  count=0
+  while [ ${count} -lt ${var_count} ]; do
+    export ${custom_vars[count]}
+  count=$(( $count + 1 ))
+  done
+fi
+
+declare -A UDF_VARS
+
+if [[ -n "${USER_NAME}" ]]; then
+        UDF_VARS["USER_NAME"]="${USER_NAME}"
+else
+        UDF_VARS["USER_NAME"]="admin" # default
+fi
+
+if [[ -n "${DISABLE_ROOT}" ]]; then
+        UDF_VARS["DISABLE_ROOT"]="${DISABLE_ROOT}"
+else
+        UDF_VARS["DISABLE_ROOT"]="No" # default
+fi
+
+if [[ -n "${SOA_EMAIL_ADDRESS}" ]]; then
+        UDF_VARS["SOA_EMAIL_ADDRESS"]="${SOA_EMAIL_ADDRESS}"
+else
+        UDF_VARS["SOA_EMAIL_ADDRESS"]="webmaster@${DEFAULT_DNS}" # default
+fi
+
+if [[ -n "${DOMAIN}" ]]; then
+        UDF_VARS["DOMAIN"]="${DOMAIN}"
+else
+        UDF_VARS["DOMAIN"]="" # default
+fi
+
+if [[ -n "${SUBDOMAIN}" ]]; then
+        UDF_VARS["SUBDOMAIN"]="${SUBDOMAIN}"
+else
+        UDF_VARS["SUBDOMAIN"]="" # default
+fi
+
+if [[ -n "${TOKEN_PASSWORD}" ]]; then
+        UDF_VARS["TOKEN_PASSWORD"]="${TOKEN_PASSWORD}"
+else
+        UDF_VARS["TOKEN_PASSWORD"]="" # default
+fi
+
+if [[ -n "${OPENWEBUI_LOGIN_NAME}" ]]; then
+        UDF_VARS["OPENWEBUI_LOGIN_NAME"]="${OPENWEBUI_LOGIN_NAME}"
+else
+        UDF_VARS["OPENWEBUI_LOGIN_NAME"]="Open WebUI" # default
+fi
+
+if [[ -n "${OPENWEBUI_LOGIN_EMAIL}" ]]; then
+        UDF_VARS["OPENWEBUI_LOGIN_EMAIL"]="${OPENWEBUI_LOGIN_EMAIL}"
+else
+        UDF_VARS["OPENWEBUI_LOGIN_EMAIL"]="webmaster@${DEFAULT_DNS}" # default
+fi
+
+if [[ -n "${DEEPSEEK_MODEL_SIZE}" ]]; then
+        UDF_VARS["DEEPSEEK_MODEL_SIZE"]="${DEEPSEEK_MODEL_SIZE}"
+else
+        UDF_VARS["DEEPSEEK_MODEL_SIZE"]="7B" # default
+fi
+
+if [[ -n "${ADD_ONS}" ]]; then
+        UDF_VARS["ADD_ONS"]="${ADD_ONS}"
+else
+        UDF_VARS["ADD_ONS"]="none" # default
+fi
+
+set_vars() {
+  for key in "${!UDF_VARS[@]}"; do
+    export "${key}"="${UDF_VARS[$key]}"
+  done
+}
+
+# main
+set_vars

--- a/deployment_scripts/linode-marketplace-ollama/test-vars.sh
+++ b/deployment_scripts/linode-marketplace-ollama/test-vars.sh
@@ -72,7 +72,7 @@ fi
 if [[ -n "${LLM}" ]]; then
         UDF_VARS["LLM"]="${LLM}"
 else
-        UDF_VARS["LLM"]="qwen" # default
+        UDF_VARS["LLM"]="llama3.2:3b" # default
 fi
 
 set_vars() {

--- a/deployment_scripts/linode-marketplace-ollama/test-vars.sh
+++ b/deployment_scripts/linode-marketplace-ollama/test-vars.sh
@@ -63,16 +63,16 @@ else
         UDF_VARS["OPENWEBUI_LOGIN_EMAIL"]="webmaster@${DEFAULT_DNS}" # default
 fi
 
-if [[ -n "${OPENWEBUI_ENABLED}" ]]; then
-        UDF_VARS["OPENWEBUI_ENABLED"]="${OPENWEBUI_ENABLED}"
-else
-        UDF_VARS["OPENWEBUI_ENABLED"]="Yes" # default
-fi
-
 if [[ -n "${ADD_ONS}" ]]; then
         UDF_VARS["ADD_ONS"]="${ADD_ONS}"
 else
         UDF_VARS["ADD_ONS"]="none" # default
+fi
+
+if [[ -n "${LLM}" ]]; then
+        UDF_VARS["LLM"]="${LLM}"
+else
+        UDF_VARS["LLM"]="qwen" # default
 fi
 
 set_vars() {

--- a/deployment_scripts/linode-marketplace-ollama/test-vars.sh
+++ b/deployment_scripts/linode-marketplace-ollama/test-vars.sh
@@ -63,10 +63,10 @@ else
         UDF_VARS["OPENWEBUI_LOGIN_EMAIL"]="webmaster@${DEFAULT_DNS}" # default
 fi
 
-if [[ -n "${DEEPSEEK_MODEL_SIZE}" ]]; then
-        UDF_VARS["DEEPSEEK_MODEL_SIZE"]="${DEEPSEEK_MODEL_SIZE}"
+if [[ -n "${OPENWEBUI_ENABLED}" ]]; then
+        UDF_VARS["OPENWEBUI_ENABLED"]="${OPENWEBUI_ENABLED}"
 else
-        UDF_VARS["DEEPSEEK_MODEL_SIZE"]="7B" # default
+        UDF_VARS["OPENWEBUI_ENABLED"]="Yes" # default
 fi
 
 if [[ -n "${ADD_ONS}" ]]; then


### PR DESCRIPTION
[Add] Ollama Quick Deploy App:

This app deploys Ollama along with OpenwebUI :)

GPU Required. UDF allows the user to enter a model they would like to use, in the event that the model is invalid, a specific error message will display letting the user know it's invalid & to check the available LLMs for ollama at the ollama library. Users can add more LLMs but simply logging into the docker container for ollama and running 

`ollama pull $LLM`
Example:
`ollama pull qwen`
This will pull the latest qwen LLM available

