### PR TITLE
[Fix] Antmedia enterprise password issue

### DIFF
--- a/apps/linode-marketplace-antmedia-community/roles/antmedia/tasks/main.yml
+++ b/apps/linode-marketplace-antmedia-community/roles/antmedia/tasks/main.yml
@@ -42,7 +42,7 @@
     headers:
       Content-Type: 'application/json'
   register: antmedia_result
-  until: antmedia_result.status != 403
+  # until: antmedia_result.status != 403
   retries: 5
   delay: 10
 

--- a/apps/linode-marketplace-antmedia-community/roles/antmedia/tasks/main.yml
+++ b/apps/linode-marketplace-antmedia-community/roles/antmedia/tasks/main.yml
@@ -42,7 +42,7 @@
     headers:
       Content-Type: 'application/json'
   register: antmedia_result
-  # until: antmedia_result.status != 403
+  until: antmedia_result.status != 403
   retries: 5
   delay: 10
 

--- a/apps/linode-marketplace-antmedia/roles/antmedia/tasks/main.yml
+++ b/apps/linode-marketplace-antmedia/roles/antmedia/tasks/main.yml
@@ -43,7 +43,7 @@
     headers:
       Content-Type: 'application/json'
   register: antmedia_result
-  # until: antmedia_result.status == 200
+  until: antmedia_result.status == 200
   retries: 5
   delay: 10
 

--- a/apps/linode-marketplace-antmedia/roles/antmedia/tasks/main.yml
+++ b/apps/linode-marketplace-antmedia/roles/antmedia/tasks/main.yml
@@ -37,13 +37,13 @@
     body_format: json
     body:
       email: "{{ soa_email_address }}"
-      password: "{{ antmedia_password }}"
+      password: "{{ antmedia_password | hash('md5') }}"
       scope: 'system'
       userType: 'ADMIN'
     headers:
       Content-Type: 'application/json'
   register: antmedia_result
-  until: antmedia_result.status == 200
+  # until: antmedia_result.status == 200
   retries: 5
   delay: 10
 


### PR DESCRIPTION
## Ant Media Enterprise — admin login fails with "Username or password is incorrect"

### Symptom
After deploying the Ant Media Enterprise marketplace app, logging into the web console at `https://<host>:5443` with the generated credentials from `/home/<user>/.credentials` returns "Username or password is incorrect." The community edition is unaffected.

### Why only enterprise?
The two apps pin different Ant Media Server versions via the `antmedia_zip_remote_url` in the role:

```
# Community:  pinned to v2.9.0
$ ls /usr/local/antmedia | grep StreamApp
StreamApp-2.9.0.war

# Enterprise: tracks `latest.zip`, currently v3.0.1
$ ls /usr/local/antmedia | grep StreamApp
StreamApp-3.0.1.war
```

### Root cause — asymmetric MD5 hashing between registration and login
Ant Media Server v3.0 MD5-hashes the password on both ends of the flow: once when the admin user is created, and once again on every login attempt. Our Ansible playbook was only accounting for one of those hashes, so registration and login ended up in different namespaces.

Concretely, let `P` = the raw generated password and `MD5(x)` = MD5 hex digest of `x`.

```
REGISTRATION (POST /rest/v2/users/initial)
  Ansible (buggy):  sends P         → server stores MD5(P)

LOGIN (POST /rest/v2/users/authenticate from the browser)
  Angular UI:       sends MD5(P)    (the UI MD5-hashes client-side)
  Server:           computes MD5( MD5(P) ) and compares against storage
  Comparison:       MD5(MD5(P))  vs  stored MD5(P)   →  MISMATCH  → "incorrect"
```

The Angular login code MD5-hashes the typed password client-side before it leaves the browser (confirmed by looking at `main-es5.*.js` in the AMS webapp — `c(e)` in the `login()` function is an MD5 implementation with `.toLowerCase()`), and the server-side MD5 happens in `CommonRestService.addInitialUser` / `authenticateUser`:

> https://github.com/ant-media/Ant-Media-Server/blob/master/src/main/java/io/antmedia/console/rest/CommonRestService.java

So the server's end-to-end behavior is **client-posted-value → MD5 → DB**, on both writes and reads. Whatever the client posts at registration has to equal whatever the client posts at login. Those values weren't equal: Ansible was posting the raw password, the browser was posting its MD5.

### Fix
Pre-hash the password in Ansible so the value Ansible posts at registration matches the value the browser posts at login:

```yaml
# apps/linode-marketplace-antmedia/roles/antmedia/tasks/main.yml
body:
  email: "{{ soa_email_address }}"
  password: "{{ antmedia_password | hash('md5') }}"   # ← the fix
  scope: 'system'
  userType: 'ADMIN'
```

After the fix:

```
REGISTRATION:
  Ansible (fixed):  sends MD5(P)    → server stores MD5( MD5(P) )

LOGIN:
  Angular UI:       sends MD5(P)
  Server:           computes MD5( MD5(P) ) and compares against storage
  Comparison:       MD5(MD5(P))  vs  stored MD5(MD5(P))  →  MATCH  → success
```

The raw password in `/home/<user>/.credentials` is unchanged — the user still types `P` into the login form — only the value Ansible puts in the database is shifted by one MD5 step to stay in sync with what the browser submits.