### PR TITLE
[Update] Add set -e to stackscripts - Batch 3

### DIFF
--- a/deployment_scripts/linode-marketplace-liveswitch/liveswitch-deploy.sh
+++ b/deployment_scripts/linode-marketplace-liveswitch/liveswitch-deploy.sh
@@ -5,13 +5,23 @@ exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-mastodon/mastodon-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mastodon/mastodon-deploy.sh
@@ -3,8 +3,9 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
@@ -22,6 +23,7 @@ if [ "${MODE}" == "staging" ]; then
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH Security Settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-mean/mean-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mean/mean-deploy.sh
@@ -5,13 +5,23 @@ exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-memgraph/memgraph-deploy.sh
+++ b/deployment_scripts/linode-marketplace-memgraph/memgraph-deploy.sh
@@ -3,8 +3,9 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
@@ -22,6 +23,7 @@ if [ "${MODE}" == "staging" ]; then
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH security settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-mern/mern-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mern/mern-deploy.sh
@@ -5,13 +5,23 @@ exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-milvus/milvus-deploy.sh
+++ b/deployment_scripts/linode-marketplace-milvus/milvus-deploy.sh
@@ -3,6 +3,7 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
 # DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
@@ -13,11 +14,16 @@ else
   trap "cleanup $? $LINENO" EXIT
 fi
 
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
 if [ "${MODE}" == "staging" ]; then
   trap "provision_failed $? $LINENO" ERR
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH Security Settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-moodle/moodle-deploy.sh
+++ b/deployment_scripts/linode-marketplace-moodle/moodle-deploy.sh
@@ -5,13 +5,23 @@ exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-mysql/mysql-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mysql/mysql-deploy.sh
@@ -5,13 +5,23 @@ exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-nats-single-node/nats-single-node-deploy.sh
+++ b/deployment_scripts/linode-marketplace-nats-single-node/nats-single-node-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-neo4j/neo4j-deploy.sh
+++ b/deployment_scripts/linode-marketplace-neo4j/neo4j-deploy.sh
@@ -3,8 +3,9 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
@@ -22,6 +23,7 @@ if [ "${MODE}" == "staging" ]; then
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH security settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-netfoundry-edge-router/netfoundry-edge-router-deploy.sh
+++ b/deployment_scripts/linode-marketplace-netfoundry-edge-router/netfoundry-edge-router-deploy.sh
@@ -5,13 +5,23 @@ exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-nextcloud/nextcloud-deploy.sh
+++ b/deployment_scripts/linode-marketplace-nextcloud/nextcloud-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-nodejs/nodejs-deploy.sh
+++ b/deployment_scripts/linode-marketplace-nodejs/nodejs-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-odoo/odoo-deploy.sh
+++ b/deployment_scripts/linode-marketplace-odoo/odoo-deploy.sh
@@ -1,6 +1,29 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
+
+# BEGIN CI-MODE
+# modes
+# DEBUG="NO"
+if [[ -n ${DEBUG} ]]; then
+  if [ "${DEBUG}" == "NO" ]; then
+    trap "cleanup $? $LINENO" EXIT
+  fi
+else
+  trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
+fi
+# END CI-MODE
 
 
 

--- a/deployment_scripts/linode-marketplace-ollama/ollama-deploy.sh
+++ b/deployment_scripts/linode-marketplace-ollama/ollama-deploy.sh
@@ -5,7 +5,7 @@ exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT

--- a/deployment_scripts/linode-marketplace-open-webui/open-webui-deploy.sh
+++ b/deployment_scripts/linode-marketplace-open-webui/open-webui-deploy.sh
@@ -3,8 +3,9 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
@@ -22,6 +23,7 @@ if [ "${MODE}" == "staging" ]; then
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH security settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-openbao/openbao-deploy.sh
+++ b/deployment_scripts/linode-marketplace-openbao/openbao-deploy.sh
@@ -3,8 +3,9 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
@@ -13,11 +14,16 @@ else
   trap "cleanup $? $LINENO" EXIT
 fi
 
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
 if [ "${MODE}" == "staging" ]; then
   trap "provision_failed $? $LINENO" ERR
 else
   set -e
 fi
+# END CI-MODE
 
 ##Linode/SSH security settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-openclaw/openclaw-deploy.sh
+++ b/deployment_scripts/linode-marketplace-openclaw/openclaw-deploy.sh
@@ -3,6 +3,7 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
 # DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
@@ -13,11 +14,16 @@ else
   trap "cleanup $? $LINENO" EXIT
 fi
 
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
 if [ "${MODE}" == "staging" ]; then
   trap "provision_failed $? $LINENO" ERR
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH security settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-openlitespeed-django/openlitespeed-django-deploy.sh
+++ b/deployment_scripts/linode-marketplace-openlitespeed-django/openlitespeed-django-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-openlitespeed-wordpress/openlitespeed-wordpress-deploy.sh
+++ b/deployment_scripts/linode-marketplace-openlitespeed-wordpress/openlitespeed-wordpress-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 


### PR DESCRIPTION
- Add missing `set -e` to stackscripts to trigger traps:
```
if [ "${MODE}" == "staging" ]; then
  trap "provision_failed $? $LINENO" ERR
else
  set -e
fi
```

App deploy scripts updated:
- liveswitch
- mastodon
- mean
- memgraph
- mern
- milvus
- moodle
- mysql
- nats-single-node
- neo4j
- netfoundry-edge-router
- nextcloud
- nodejs
- odoo
- ollama
- open-webui
- openbao
- openclaw
- openlitespeed-django
- openlitespeed-wordpress