### PR TITLE
[Update] Add set -e to stackscripts - Batch 4

### DIFF
--- a/deployment_scripts/linode-marketplace-openvpn/openvpn-deploy.sh
+++ b/deployment_scripts/linode-marketplace-openvpn/openvpn-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-owncast/owncast-deploy.sh
+++ b/deployment_scripts/linode-marketplace-owncast/owncast-deploy.sh
@@ -5,13 +5,23 @@ exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-passbolt/passbolt-deploy.sh
+++ b/deployment_scripts/linode-marketplace-passbolt/passbolt-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
@@ -12,6 +13,10 @@ if [[ -n ${DEBUG} ]]; then
 else
   trap "cleanup $? $LINENO" EXIT
 fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
 
 if [ "${MODE}" == "staging" ]; then
   trap "provision_failed $? $LINENO" ERR

--- a/deployment_scripts/linode-marketplace-peppermint/peppermint-deploy.sh
+++ b/deployment_scripts/linode-marketplace-peppermint/peppermint-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-pgvector/pgvector-deploy.sh
+++ b/deployment_scripts/linode-marketplace-pgvector/pgvector-deploy.sh
@@ -3,8 +3,9 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
@@ -22,6 +23,7 @@ if [ "${MODE}" == "staging" ]; then
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH security settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-pihole/pihole-deploy.sh
+++ b/deployment_scripts/linode-marketplace-pihole/pihole-deploy.sh
@@ -5,13 +5,23 @@ exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-plesk/plesk-deploy.sh
+++ b/deployment_scripts/linode-marketplace-plesk/plesk-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-plex/plex-deploy.sh
+++ b/deployment_scripts/linode-marketplace-plex/plex-deploy.sh
@@ -1,16 +1,27 @@
-#!/bin/bash 
+#!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-postgresql/postgresql-deploy.sh
+++ b/deployment_scripts/linode-marketplace-postgresql/postgresql-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-pritunl/pritunl-deploy.sh
+++ b/deployment_scripts/linode-marketplace-pritunl/pritunl-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-prometheus-grafana/prometheus-grafana-deploy.sh
+++ b/deployment_scripts/linode-marketplace-prometheus-grafana/prometheus-grafana-deploy.sh
@@ -5,13 +5,23 @@ exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-qwen/qwen-deploy.sh
+++ b/deployment_scripts/linode-marketplace-qwen/qwen-deploy.sh
@@ -3,8 +3,9 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
@@ -22,6 +23,7 @@ if [ "${MODE}" == "staging" ]; then
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH security settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-rabbitmq/rabbitmq-deploy.sh
+++ b/deployment_scripts/linode-marketplace-rabbitmq/rabbitmq-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-redis/redis-deploy.sh
+++ b/deployment_scripts/linode-marketplace-redis/redis-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-rocketchat/rocketchat-deploy.sh
+++ b/deployment_scripts/linode-marketplace-rocketchat/rocketchat-deploy.sh
@@ -3,8 +3,9 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
@@ -13,11 +14,16 @@ else
   trap "cleanup $? $LINENO" EXIT
 fi
 
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
 if [ "${MODE}" == "staging" ]; then
   trap "provision_failed $? $LINENO" ERR
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH security settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">


### PR DESCRIPTION
- Add missing `set -e` to stackscripts to trigger traps:
```
if [ "${MODE}" == "staging" ]; then
  trap "provision_failed $? $LINENO" ERR
else
  set -e
fi
```

App deploy scripts updated:
- openvpn
- owncast
- passbolt
- peppermint
- pgvector
- pihole
- plesk 
- plex
- postgresql
- pritunl
- prometheus-grafana
- qwen
- rabbitmq
- redis
- rocketchat