### PR TITLE
[Update] Add set -e to stackscripts - Batch 5

### DIFF
--- a/deployment_scripts/linode-marketplace-ruby-rails/ruby-rails-deploy.sh
+++ b/deployment_scripts/linode-marketplace-ruby-rails/ruby-rails-deploy.sh
@@ -3,8 +3,9 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
@@ -22,6 +23,7 @@ if [ "${MODE}" == "staging" ]; then
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH security settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-secure-your-server/secure-your-server-deploy.sh
+++ b/deployment_scripts/linode-marketplace-secure-your-server/secure-your-server-deploy.sh
@@ -3,8 +3,9 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
@@ -22,6 +23,7 @@ if [ "${MODE}" == "staging" ]; then
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH security settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-shadowsocks/shadowsocks-deploy.sh
+++ b/deployment_scripts/linode-marketplace-shadowsocks/shadowsocks-deploy.sh
@@ -5,13 +5,23 @@ exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-simplex-chat/simplex-chat-deploy.sh
+++ b/deployment_scripts/linode-marketplace-simplex-chat/simplex-chat-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-splunk/splunk-deploy.sh
+++ b/deployment_scripts/linode-marketplace-splunk/splunk-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-uptimekuma/uptimekuma-deploy.sh
+++ b/deployment_scripts/linode-marketplace-uptimekuma/uptimekuma-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-valkey/valkey-deploy.sh
+++ b/deployment_scripts/linode-marketplace-valkey/valkey-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-wazuh/wazuh-deploy.sh
+++ b/deployment_scripts/linode-marketplace-wazuh/wazuh-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-weaviate/weaviate-deploy.sh
+++ b/deployment_scripts/linode-marketplace-weaviate/weaviate-deploy.sh
@@ -3,6 +3,7 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
 # DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
@@ -13,11 +14,16 @@ else
   trap "cleanup $? $LINENO" EXIT
 fi
 
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
 if [ "${MODE}" == "staging" ]; then
   trap "provision_failed $? $LINENO" ERR
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH security settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-wireguard-client/wireguard-client-deploy.sh
+++ b/deployment_scripts/linode-marketplace-wireguard-client/wireguard-client-deploy.sh
@@ -3,8 +3,9 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
@@ -13,11 +14,16 @@ else
   trap "cleanup $? $LINENO" EXIT
 fi
 
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
 if [ "${MODE}" == "staging" ]; then
   trap "provision_failed $? $LINENO" ERR
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH security settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-wireguard-server/wireguard-server-deploy.sh
+++ b/deployment_scripts/linode-marketplace-wireguard-server/wireguard-server-deploy.sh
@@ -3,8 +3,9 @@
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
+# BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
@@ -13,11 +14,16 @@ else
   trap "cleanup $? $LINENO" EXIT
 fi
 
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
 if [ "${MODE}" == "staging" ]; then
   trap "provision_failed $? $LINENO" ERR
 else
   set -e
 fi
+# END CI-MODE
 
 ## Linode/SSH security settings
 #<UDF name="user_name" label="The limited sudo user to be created for the Linode: *No Capital Letters or Special Characters*">

--- a/deployment_scripts/linode-marketplace-woocommerce/woocommerce-deploy.sh
+++ b/deployment_scripts/linode-marketplace-woocommerce/woocommerce-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-wordpress/wordpress-deploy.sh
+++ b/deployment_scripts/linode-marketplace-wordpress/wordpress-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 

--- a/deployment_scripts/linode-marketplace-zabbix/zabbix-deploy.sh
+++ b/deployment_scripts/linode-marketplace-zabbix/zabbix-deploy.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 
 # BEGIN CI-MODE
 # modes
-#DEBUG="NO"
+# DEBUG="NO"
 if [[ -n ${DEBUG} ]]; then
   if [ "${DEBUG}" == "NO" ]; then
     trap "cleanup $? $LINENO" EXIT
   fi
 else
   trap "cleanup $? $LINENO" EXIT
+fi
+
+# cleanup will always happen. If DEBUG is passed and is anything
+# other than NO, it will always trigger cleanup. This is useful for
+# ci testing and passing vars to the instance.
+
+if [ "${MODE}" == "staging" ]; then
+  trap "provision_failed $? $LINENO" ERR
+else
+  set -e
 fi
 # END CI-MODE
 


### PR DESCRIPTION
- Add missing `set -e` to stackscripts to trigger traps:
```
if [ "${MODE}" == "staging" ]; then
  trap "provision_failed $? $LINENO" ERR
else
  set -e
fi
```

App deploy scripts updated:
- ruby-rails
- secure-your-server
- shadowsocks
- simplex-chat
- splunk
- uptimekuma
- valkey
- wazuh
- weaviate
- wireguard-client
- wireguard-server
- woocommerce
- wordpress
- zabbix