### PR TITLE
[Update] Add Stackscript ID to Deployment Scripts 

### DIFF
--- a/deployment_scripts/linode-marketplace-aapanel/aapanel-deploy.sh
+++ b/deployment_scripts/linode-marketplace-aapanel/aapanel-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 869129
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-antmedia-community/antmedia-community-deploy.sh
+++ b/deployment_scripts/linode-marketplace-antmedia-community/antmedia-community-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 804144
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-antmedia/antmedia-deploy.sh
+++ b/deployment_scripts/linode-marketplace-antmedia/antmedia-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 985374
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-apache-airflow/apache-airflow-deploy.sh
+++ b/deployment_scripts/linode-marketplace-apache-airflow/apache-airflow-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1102900
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-arangodb/arangodb-deploy.sh
+++ b/deployment_scripts/linode-marketplace-arangodb/arangodb-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1873119
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-azuracast/azuracast-deploy.sh
+++ b/deployment_scripts/linode-marketplace-azuracast/azuracast-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 662118
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-backstage/backstage-deploy.sh
+++ b/deployment_scripts/linode-marketplace-backstage/backstage-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1646305
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-beef/beef-deploy.sh
+++ b/deployment_scripts/linode-marketplace-beef/beef-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 913277
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-benchkit/benchkit-deploy.sh
+++ b/deployment_scripts/linode-marketplace-benchkit/benchkit-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 2095382
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-chroma/chroma-deploy.sh
+++ b/deployment_scripts/linode-marketplace-chroma/chroma-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1976719
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-cloudron/cloudron-deploy.sh
+++ b/deployment_scripts/linode-marketplace-cloudron/cloudron-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 691621
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-code-server/code-server-deploy.sh
+++ b/deployment_scripts/linode-marketplace-code-server/code-server-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 688903
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-cpanel-almalinux/cpanel-almalinux-deploy.sh
+++ b/deployment_scripts/linode-marketplace-cpanel-almalinux/cpanel-almalinux-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 595742
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-cpanel-ubuntu/cpanel-ubuntu-deploy.sh
+++ b/deployment_scripts/linode-marketplace-cpanel-ubuntu/cpanel-ubuntu-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 595742
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-cribl/cribl-deploy.sh
+++ b/deployment_scripts/linode-marketplace-cribl/cribl-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1902903
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-cyberpanel/cyberpanel-deploy.sh
+++ b/deployment_scripts/linode-marketplace-cyberpanel/cyberpanel-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 741206
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-deepseek/deepseek-deploy.sh
+++ b/deployment_scripts/linode-marketplace-deepseek/deepseek-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 2025976
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-django/django-deploy.sh
+++ b/deployment_scripts/linode-marketplace-django/django-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 609175
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-docker/docker-deploy.sh
+++ b/deployment_scripts/linode-marketplace-docker/docker-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 607433
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-drupal/drupal-deploy.sh
+++ b/deployment_scripts/linode-marketplace-drupal/drupal-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 401698
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-filecloud/filecloud-deploy.sh
+++ b/deployment_scripts/linode-marketplace-filecloud/filecloud-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 691620
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-flask/flask-deploy.sh
+++ b/deployment_scripts/linode-marketplace-flask/flask-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 609392
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-focalboard/focalboard-deploy.sh
+++ b/deployment_scripts/linode-marketplace-focalboard/focalboard-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 971045
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-gemma3/gemma3-deploy.sh
+++ b/deployment_scripts/linode-marketplace-gemma3/gemma3-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1997012
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-gitea/gitea-deploy.sh
+++ b/deployment_scripts/linode-marketplace-gitea/gitea-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 688911
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-gitlab/gitlab-deploy.sh
+++ b/deployment_scripts/linode-marketplace-gitlab/gitlab-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 401707
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-gpt-oss/gpt-oss-deploy.sh
+++ b/deployment_scripts/linode-marketplace-gpt-oss/gpt-oss-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 2011885
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-grav/grav-deploy.sh
+++ b/deployment_scripts/linode-marketplace-grav/grav-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 970559
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-guacamole/guacamole-deploy.sh
+++ b/deployment_scripts/linode-marketplace-guacamole/guacamole-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 688914
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-harbor/harbor-deploy.sh
+++ b/deployment_scripts/linode-marketplace-harbor/harbor-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 912262
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-influxdb/influxdb-deploy.sh
+++ b/deployment_scripts/linode-marketplace-influxdb/influxdb-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1403817
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-jaeger/jaeger-deploy.sh
+++ b/deployment_scripts/linode-marketplace-jaeger/jaeger-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1902904
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-jenkins/jenkins-deploy.sh
+++ b/deployment_scripts/linode-marketplace-jenkins/jenkins-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 607401
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-jitsi/jitsi-deploy.sh
+++ b/deployment_scripts/linode-marketplace-jitsi/jitsi-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 662121
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-joplin/joplin-deploy.sh
+++ b/deployment_scripts/linode-marketplace-joplin/joplin-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 985380
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-jupyterlab/jupyterlab-deploy.sh
+++ b/deployment_scripts/linode-marketplace-jupyterlab/jupyterlab-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1298017
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-kali-linux/kali-linux-deploy.sh
+++ b/deployment_scripts/linode-marketplace-kali-linux/kali-linux-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1017300
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-lamp/lamp-deploy.sh
+++ b/deployment_scripts/linode-marketplace-lamp/lamp-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 401701
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-lemp/lemp-deploy.sh
+++ b/deployment_scripts/linode-marketplace-lemp/lemp-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 606691
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-linuxgsm/linuxgsm-deploy.sh
+++ b/deployment_scripts/linode-marketplace-linuxgsm/linuxgsm-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1329462
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-liveswitch/liveswitch-deploy.sh
+++ b/deployment_scripts/linode-marketplace-liveswitch/liveswitch-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1008123
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-mastodon/mastodon-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mastodon/mastodon-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1096122
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-mc-ffmpeg-demo/mc-ffmpeg-demo-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mc-ffmpeg-demo/mc-ffmpeg-demo-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1243759
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-mc-live-encoder-demo/mc-live-encoder-demo-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mc-live-encoder-demo/mc-live-encoder-demo-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1243760
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-mc-p2-avc-demo/mc-p2-avc-demo-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mc-p2-avc-demo/mc-p2-avc-demo-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1243762
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-mc-xavc-demo/mc-xavc-demo-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mc-xavc-demo/mc-xavc-demo-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1243763
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-mc-xdcam-demo/mc-xdcam-demo-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mc-xdcam-demo/mc-xdcam-demo-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1243764
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-mean/mean-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mean/mean-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 611895
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-memgraph/memgraph-deploy.sh
+++ b/deployment_scripts/linode-marketplace-memgraph/memgraph-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1878106
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-mern/mern-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mern/mern-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 401702
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-milvus/milvus-deploy.sh
+++ b/deployment_scripts/linode-marketplace-milvus/milvus-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 2011033
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-moodle/moodle-deploy.sh
+++ b/deployment_scripts/linode-marketplace-moodle/moodle-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 869127
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-mysql/mysql-deploy.sh
+++ b/deployment_scripts/linode-marketplace-mysql/mysql-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 607026
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-nats-single-node/nats-single-node-deploy.sh
+++ b/deployment_scripts/linode-marketplace-nats-single-node/nats-single-node-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1308539
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-neo4j/neo4j-deploy.sh
+++ b/deployment_scripts/linode-marketplace-neo4j/neo4j-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1884304
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-netfoundry-edge-router/netfoundry-edge-router-deploy.sh
+++ b/deployment_scripts/linode-marketplace-netfoundry-edge-router/netfoundry-edge-router-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1785544
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-nextcloud/nextcloud-deploy.sh
+++ b/deployment_scripts/linode-marketplace-nextcloud/nextcloud-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 632758
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-nodejs/nodejs-deploy.sh
+++ b/deployment_scripts/linode-marketplace-nodejs/nodejs-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 970561
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-odoo/odoo-deploy.sh
+++ b/deployment_scripts/linode-marketplace-odoo/odoo-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 971043
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-ollama/ollama-deploy.sh
+++ b/deployment_scripts/linode-marketplace-ollama/ollama-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 2088700
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-open-webui/open-webui-deploy.sh
+++ b/deployment_scripts/linode-marketplace-open-webui/open-webui-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1980062
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-openbao/openbao-deploy.sh
+++ b/deployment_scripts/linode-marketplace-openbao/openbao-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1403816
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-openclaw/openclaw-deploy.sh
+++ b/deployment_scripts/linode-marketplace-openclaw/openclaw-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 2049320
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-openlitespeed-django/openlitespeed-django-deploy.sh
+++ b/deployment_scripts/linode-marketplace-openlitespeed-django/openlitespeed-django-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 923029
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-openlitespeed-wordpress/openlitespeed-wordpress-deploy.sh
+++ b/deployment_scripts/linode-marketplace-openlitespeed-wordpress/openlitespeed-wordpress-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 691622
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-openvpn/openvpn-deploy.sh
+++ b/deployment_scripts/linode-marketplace-openvpn/openvpn-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 401719
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-owncast/owncast-deploy.sh
+++ b/deployment_scripts/linode-marketplace-owncast/owncast-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 804172
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-passbolt/passbolt-deploy.sh
+++ b/deployment_scripts/linode-marketplace-passbolt/passbolt-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1439640
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-peppermint/peppermint-deploy.sh
+++ b/deployment_scripts/linode-marketplace-peppermint/peppermint-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 804143
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-pgvector/pgvector-deploy.sh
+++ b/deployment_scripts/linode-marketplace-pgvector/pgvector-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1972184
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-pihole/pihole-deploy.sh
+++ b/deployment_scripts/linode-marketplace-pihole/pihole-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 970522
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-plesk/plesk-deploy.sh
+++ b/deployment_scripts/linode-marketplace-plesk/plesk-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 593835
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-plex/plex-deploy.sh
+++ b/deployment_scripts/linode-marketplace-plex/plex-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 662119
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-postgresql/postgresql-deploy.sh
+++ b/deployment_scripts/linode-marketplace-postgresql/postgresql-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 611376
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-pritunl/pritunl-deploy.sh
+++ b/deployment_scripts/linode-marketplace-pritunl/pritunl-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 925722
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-prometheus-grafana/prometheus-grafana-deploy.sh
+++ b/deployment_scripts/linode-marketplace-prometheus-grafana/prometheus-grafana-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 985364
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-qwen/qwen-deploy.sh
+++ b/deployment_scripts/linode-marketplace-qwen/qwen-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 2015845
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-rabbitmq/rabbitmq-deploy.sh
+++ b/deployment_scripts/linode-marketplace-rabbitmq/rabbitmq-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 688890
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-redis/redis-deploy.sh
+++ b/deployment_scripts/linode-marketplace-redis/redis-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 607488
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-rocketchat/rocketchat-deploy.sh
+++ b/deployment_scripts/linode-marketplace-rocketchat/rocketchat-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 912264
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-ruby-rails/ruby-rails-deploy.sh
+++ b/deployment_scripts/linode-marketplace-ruby-rails/ruby-rails-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 609048
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-secure-your-server/secure-your-server-deploy.sh
+++ b/deployment_scripts/linode-marketplace-secure-your-server/secure-your-server-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 692092
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-shadowsocks/shadowsocks-deploy.sh
+++ b/deployment_scripts/linode-marketplace-shadowsocks/shadowsocks-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 604068
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-simplex-chat/simplex-chat-deploy.sh
+++ b/deployment_scripts/linode-marketplace-simplex-chat/simplex-chat-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1243780
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-splunk/splunk-deploy.sh
+++ b/deployment_scripts/linode-marketplace-splunk/splunk-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 869153
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-uptimekuma/uptimekuma-deploy.sh
+++ b/deployment_scripts/linode-marketplace-uptimekuma/uptimekuma-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 970523
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-valkey/valkey-deploy.sh
+++ b/deployment_scripts/linode-marketplace-valkey/valkey-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1403815
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-wazuh/wazuh-deploy.sh
+++ b/deployment_scripts/linode-marketplace-wazuh/wazuh-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 913276
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-weaviate/weaviate-deploy.sh
+++ b/deployment_scripts/linode-marketplace-weaviate/weaviate-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1966231
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-wireguard-client/wireguard-client-deploy.sh
+++ b/deployment_scripts/linode-marketplace-wireguard-client/wireguard-client-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 1914317
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-wireguard-server/wireguard-server-deploy.sh
+++ b/deployment_scripts/linode-marketplace-wireguard-server/wireguard-server-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 401706
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-woocommerce/woocommerce-deploy.sh
+++ b/deployment_scripts/linode-marketplace-woocommerce/woocommerce-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 401708
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-wordpress/wordpress-deploy.sh
+++ b/deployment_scripts/linode-marketplace-wordpress/wordpress-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 401697
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1

--- a/deployment_scripts/linode-marketplace-yacht/yacht-deploy.sh
+++ b/deployment_scripts/linode-marketplace-yacht/yacht-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 741207
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
 

--- a/deployment_scripts/linode-marketplace-zabbix/zabbix-deploy.sh
+++ b/deployment_scripts/linode-marketplace-zabbix/zabbix-deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# STACKSCRIPT_ID: 741208
 
 # enable logging
 exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1


### PR DESCRIPTION
## Description

- Add "# STACKSCRIPT_ID:" to deployment scripts. This will allow us to match the stackscripts in Github and the Linode API.

---

## Type of Change

- [ ] New App
- [ ] Bug Fix
- [x] Update / Refactor
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

---

## Linked Issues

OCA-1740

---

## Changes

- All deployment scripts updated to include their "# STACKSCRIPT_ID:" in the API.

---

## How to Test

<!-- Describe how to test this change. Include any required configuration (UDF variables, region, plan, image, credentials, etc.) and the expected outcome. -->

NA

---

## Checklist

- [x] Ansible lint passes
- [x] Deployed and tested end-to-end on Akamai Compute
- [x] App is reachable and functional after deployment
- [x] No hardcoded secrets, tokens, or credentials
- [ ] Relevant reviewers assigned

---

## Additional Notes

<!-- Anything else reviewers should know — known limitations, follow-up tasks, or context that doesn't fit above. -->
