### PR TITLE
[fix] Backstage & Passbolt domains issue

### DIFF
--- a/apps/linode-marketplace-passbolt/roles/common/tasks/main.yml
+++ b/apps/linode-marketplace-passbolt/roles/common/tasks/main.yml
@@ -17,6 +17,7 @@
     target: "{{ _domain }}"
     priority: 10
     state: present
+  when: [token_password is defined, default_dns is not defined]
 
 - name: Create SPF records for domain
   linode.cloud.domain_record:
@@ -26,6 +27,7 @@
     type: "TXT"
     target: "v=spf1 a ~all"
     state: present
+  when: [token_password is defined, default_dns is not defined]
 
 - name: Create RDNS records for domain
   linode.cloud.ip_rdns:
@@ -33,6 +35,7 @@
     state: present
     address: "{{ ansible_default_ipv4.address }}"
     rdns: "{{ _domain }}"
+  when: [token_password is defined, default_dns is not defined]
 
 - name: Set ssh pubkey
   import_role:

--- a/deployment_scripts/linode-marketplace-backstage/test-vars.sh
+++ b/deployment_scripts/linode-marketplace-backstage/test-vars.sh
@@ -41,15 +41,13 @@ fi
 if [[ -n "${SUBDOMAIN}" ]]; then
         UDF_VARS["SUBDOMAIN"]="${SUBDOMAIN}"
 else
-        UDF_VARS["SUBDOMAIN"]="${RANDOM_SUBDOMAIN}"
+        UDF_VARS["SUBDOMAIN"]=""
 fi
 
 if [[ -n "${DOMAIN}" ]]; then
         UDF_VARS["DOMAIN"]="${DOMAIN}"
-elif [[ -n "${LINODE_DOMAIN}" ]]; then
-        UDF_VARS["DOMAIN"]="${LINODE_DOMAIN}"
 else
-        UDF_VARS["DOMAIN"]="${DEFAULT_DNS}" # default
+        UDF_VARS["DOMAIN"]="" # default
 fi
 
 if [[ -n "${ADD_ONS}" ]]; then

--- a/deployment_scripts/linode-marketplace-passbolt/test-vars.sh
+++ b/deployment_scripts/linode-marketplace-passbolt/test-vars.sh
@@ -32,16 +32,14 @@ fi
 
 if [[ -n "${DOMAIN}" ]]; then
         UDF_VARS["DOMAIN"]="${DOMAIN}"
-elif [[ -n "${LINODE_DOMAIN}" ]]; then
-        UDF_VARS["DOMAIN"]="${LINODE_DOMAIN}"
 else
-        UDF_VARS["DOMAIN"]="${DEFAULT_DNS}" # default
+        UDF_VARS["DOMAIN"]="" # default
 fi
 
 if [[ -n "${SUBDOMAIN}" ]]; then
         UDF_VARS["SUBDOMAIN"]="${SUBDOMAIN}"
 else
-        UDF_VARS["SUBDOMAIN"]="${RANDOM_SUBDOMAIN}"
+        UDF_VARS["SUBDOMAIN"]=""
 fi
 
 if [[ -n "${TOKEN_PASSWORD}" ]]; then


### PR DESCRIPTION
## Description

Fix domain issues for Backstage and Passbolt apps.

---

## Type of Change

- [ ] New App
- [ ] Bug Fix
- [x] Update / Refactor
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

---

## Linked Issues

N/A

---

## Changes

- Removed domain & subdomain test var for Backstage and Passbolt apps;
- Added a condition to create domain records only if `default_dns` is not defined

---

## How to Test

Run Backstage and Passbolt deployments.

---

## Checklist

- [x] Ansible lint passes
- [x] Deployed and tested end-to-end on Akamai Compute
- [x] App is reachable and functional after deployment
- [x] No hardcoded secrets, tokens, or credentials
- [x] Documentation updated (if applicable)
- [x] Relevant reviewers assigned

---
