### PR TITLE
Fix for Slack merge notifications

### DIFF
--- a/.github/workflows/merge-notifications.yml
+++ b/.github/workflows/merge-notifications.yml
@@ -1,7 +1,7 @@
 name: Merge Notifications to Slack
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:


### PR DESCRIPTION
## Description

Fix for merge notifications to Slack

---

## Type of Change

- [ ] New App
- [ ] Bug Fix
- [x] Update / Refactor
- [ ] Tests
- [ ] Documentation
- [x] CI/CD

---

## Changes

- Merge notifications were not sent to Slack when a PR from a fork was merged into the `develop` branch: https://github.com/akamai-compute-marketplace/marketplace-apps/actions/runs/27217855995
- The `SLACK_WEBHOOK_URL` secret was empty because GitHub does not inject secrets into `pull_request` workflows triggered by fork PRs
- Updated the trigger from `pull_request` to `pull_request_target`, which runs the workflow in the context of the base repo with access to its secrets

---

## How to Test

- Only after merge to main the changes will apply

---

## Checklist

- [x] Ansible lint passes
- [x] Deployed and tested end-to-end on Akamai Compute
- [x] App is reachable and functional after deployment
- [x] No hardcoded secrets, tokens, or credentials
- [x] Documentation updated (if applicable)
- [x] Relevant reviewers assigned

---