### PR TITLE
Fix Apache Airflow fastapi version

### DIFF
--- a/apps/linode-marketplace-apache-airflow/roles/airflow/tasks/install.yml
+++ b/apps/linode-marketplace-apache-airflow/roles/airflow/tasks/install.yml
@@ -39,7 +39,14 @@
   pip:
     virtualenv: "{{ airflow_venv }}"
     virtualenv_command: python3 -m venv
-    name: apache-airflow
+    name:
+      - apache-airflow
+      # TODO: Remove this pin once https://github.com/fastapi/fastapi/issues/15762 is resolved.
+      # fastapi 0.137.0 introduced a breaking change where routers with both an empty prefix
+      # and empty path raise a FastAPIError. Airflow 3.2.2's cadwyn-based execution API router
+      # triggers this, causing airflow-api.service to crash on startup before generating the
+      # password file.
+      - fastapi==0.136.3
     state: present
 
 - name: Initialize Airflow metadata database


### PR DESCRIPTION
## Description

Pins `fastapi==0.136.3` in the Apache Airflow marketplace app to fix a deployment failure introduced by FastAPI 0.137.0. The new FastAPI version broke Airflow's API server startup, preventing the admin password file from being generated and causing the Ansible playbook to fail.

---

## Type of Change

- [ ] New App
- [x] Bug Fix
- [ ] Update / Refactor
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

---

## Linked Issues

- https://github.com/fastapi/fastapi/issues/15762

---

## Changes

**`apps/linode-marketplace-apache-airflow/roles/airflow/tasks/install.yml`**
- Pin `fastapi==0.136.3` to avoid a breaking change in 0.137.0 where routers with both an empty prefix and empty path raise a `FastAPIError`, crashing `airflow-api.service` before the admin password file is generated
- Added TODO comment linking to the upstream FastAPI issue for future cleanup

---

## How to Test

- Deploy the Apache Airflow 

---

## Checklist

- [x] Ansible lint passes
- [x] Deployed and tested end-to-end on Akamai Compute
- [x] App is reachable and functional after deployment
- [x] No hardcoded secrets, tokens, or credentials
- [x] Documentation updated (if applicable)
- [x] Relevant reviewers assigned

---

## Additional Notes

FastAPI 0.137.0 was released on June 15, 2026 and immediately broke Airflow 3.2.2 deployments. The pin should be removed once the upstream FastAPI issue is resolved and Airflow is confirmed compatible with the fixed FastAPI version.