### PR TITLE
Main ⬅️ Develop: Beef & Grav fix

### DIFF
--- a/apps/linode-marketplace-beef/roles/beef/tasks/main.yml
+++ b/apps/linode-marketplace-beef/roles/beef/tasks/main.yml
@@ -25,9 +25,34 @@
       - bison
       - nodejs
       - libcurl4-openssl-dev
-      - ruby-dev
+      - software-properties-common
     state: latest
     update_cache: true
+
+- name: Add Instructure Ruby PPA
+  apt_repository:
+    repo: ppa:instructure/ruby
+    state: present
+    update_cache: true
+
+- name: Install Ruby 3.3
+  apt:
+    name:
+      - ruby3.3
+      - ruby3.3-dev
+    state: present
+
+- name: Set Ruby 3.3 as the default ruby/gem/bundle/bundler
+  community.general.alternatives:
+    name: "{{ item }}"
+    link: "/usr/bin/{{ item }}"
+    path: "/usr/bin/{{ item }}3.3"
+    priority: 330
+  loop:
+    - ruby
+    - gem
+    - bundle
+    - bundler
 
 # Nginx
 - name: Config file setup

--- a/apps/linode-marketplace-beef/roles/beef/tasks/main.yml
+++ b/apps/linode-marketplace-beef/roles/beef/tasks/main.yml
@@ -126,8 +126,8 @@
     src: '{{ item.src }}'
     dest: '{{ item.dest }}'
     mode: '0600'
-    owner: '{{ username }}'
-    group: '{{ username }}'
+    owner: beef
+    group: beef
   loop:
     - { src: "/etc/letsencrypt/live/{{ _domain }}/privkey.pem", dest: "/home/beef" }
     - { src: "/etc/letsencrypt/live/{{ _domain }}/fullchain.pem", dest: "/home/beef" }
@@ -137,8 +137,8 @@
     src: 'beef_config.yaml.j2'
     dest: '/home/beef/config.yaml'
     mode: '0600'
-    owner: '{{ username }}'
-    group: '{{ username }}'
+    owner: beef
+    group: beef
 
 # update bundler gem
 - name: Manually update bundler

--- a/apps/linode-marketplace-beef/roles/beef/templates/beef_config.yaml.j2
+++ b/apps/linode-marketplace-beef/roles/beef/templates/beef_config.yaml.j2
@@ -53,10 +53,10 @@ beef:
         # If you're using a public domain name, reverse proxy, or port forwarding you must
         # configure the public-facing connection details here.
 
-        #public:
-        #    host: "beef.local" # public hostname/IP address
-        #    port: "443" # public port (443 if the public server is using HTTPS)
-        #    https: false # true/false
+        public:
+            host: "{{ _domain }}" # public hostname/IP address
+            port: "443" # public port (443 if the public server is using HTTPS)
+            https: true # true/false
 
         # If using any reverse proxy you should also set allow_reverse_proxy to true below.
         # Note that this causes the BeEF server to trust the X-Forwarded-For HTTP header.

--- a/apps/linode-marketplace-beef/roles/beef/templates/beef_service.j2
+++ b/apps/linode-marketplace-beef/roles/beef/templates/beef_service.j2
@@ -7,4 +7,4 @@ User=beef
 Group=beef
 ExecStart=/home/beef/start_beef
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/apps/linode-marketplace-grav/roles/grav/tasks/install.yml
+++ b/apps/linode-marketplace-grav/roles/grav/tasks/install.yml
@@ -61,7 +61,7 @@
 
     - name: Install Grav dependencies with Composer
       expect:
-        command: /usr/local/bin/composer install --no-dev -o
+        command: /usr/local/bin/composer install --no-dev -o --ignore-platform-req=ext-redis
         chdir: /var/www/grav
         responses:
           (?i)Do you want to continue: "yes"


### PR DESCRIPTION
## Description                                                                                                                                                                                                 
                                                                                                                                                                                                                 
Beef and Grav apps fail to deploy because of upstream dependencies:
 - https://github.com/akamai-compute-marketplace/marketplace-apps/actions/runs/27915486096/job/82600255978#step:5:1084
 - https://github.com/akamai-compute-marketplace/marketplace-apps/actions/runs/27915486096/job/82600256274#step:5:1118                               
  ---                                                                                                                                                                                                            
                                                                                                                                                                                                                 
  ## Type of Change                                                                                                                                                                                              
                                                                                                                                                                                                                 
  - [ ] New App                                                                                                                                                                                                  
  - [x] Bug Fix                                                                                                                                                                                                  
  - [ ] Update / Refactor                                                                                                                                                                                        
  - [ ] Tests                                                                                                                                                                                                    
  - [ ] Documentation                                                                                                                                                                                            
  - [ ] CI/CD                                                                                                                                                                                                    
                                                                                                                                                                                                                 
  ---

  ## Changes                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  **`apps/linode-marketplace-grav`**                                                                                                                                                                             
                                                                                                                                                                                                                 
  - **Problem:** Grav's current `composer.lock` pins `symfony/cache v7.4.13`, which declares a conflict with `ext-redis < 6.1`. Ubuntu's apt `php8.3-redis` is 5.3.7, so `composer install` fails with `rc: 2`   
  ("Your lock file does not contain a compatible set of packages").                                                                                                                                              
  - **Fix:** Added `--ignore-platform-req=ext-redis` to the Composer install command (the exact flag Composer suggests in its own error output). phpredis 5.3.7 works fine with Grav's Redis cache driver at     
  runtime; the declared conflict is conservative.                                                                                                                                                                
                                                                                                                                                                                                                 
  **`apps/linode-marketplace-beef`**                                                                                                                                                                             
                                                                                                                                                                                                                 
  - **Problem:** BeEF's `master` `Gemfile` now pins `selenium-webdriver ~> 4.45`, which requires Ruby >= 3.3. Ubuntu 24.04 ships Ruby 3.2.3, so `bundle install` fails version solving.                          
  - **Fix:** Install Ruby 3.3 from the Instructure PPA (actively maintained, supports noble) and use `update-alternatives` to make `ruby`/`gem`/`bundle`/`bundler` resolve to 3.3. Replaced the `ruby-dev` apt   
  package with `software-properties-common` + `ruby3.3`/`ruby3.3-dev`. All existing bundle steps and the systemd service run on 3.3 unchanged.                                                                   
                                                                                                                                                                                                                 
  ---

## How to Test                                                                                                                                                                                                 
                                                                                                                                                                                                                 
- Deploy each app on **Ubuntu 24.04**.                                                                                                                                                                                                                                             
                                                                                                                                                                                                                 
  ---                                                                                                                                                                                                            
                                                                                                                                                                                                                 
  ## Checklist                                                                                                                                                                                                   
                                                                                                                                                                                                                 
  - [x] Ansible lint passes                                                                                                                                                                                      
  - [x] Deployed and tested end-to-end on Akamai Compute                                                                                                                                                         
  - [x] App is reachable and functional after deployment                                                                                                                                                         
  - [x] No hardcoded secrets, tokens, or credentials                                                                                                                                                             
  - [x] Documentation updated (if applicable)                                                                                                                                                                    
  - [x] Relevant reviewers assigned                                                                                                                                                                              
                                                                                                                                                                                                                 
  --- 
              