### PR TITLE
[Fix] Update Open WebUI flags

### DIFF
--- a/apps/linode-marketplace-deepseek/roles/deepseek/templates/docker-compose.yml.j2
+++ b/apps/linode-marketplace-deepseek/roles/deepseek/templates/docker-compose.yml.j2
@@ -21,6 +21,8 @@ services:
       - --gpu-memory-utilization=0.90
       - --tensor-parallel-size={{ tensor_parallel_size }}
       - --max-num-seqs=64
+      - --enable-auto-tool-choice
+      - --tool-call-parser=hermes
     healthcheck:
       test: ["CMD", "curl", "-f", "-s", "http://localhost:8000/v1/models"]
       interval: 10s

--- a/apps/linode-marketplace-gemma3/roles/gemma3/templates/docker-compose.yml.j2
+++ b/apps/linode-marketplace-gemma3/roles/gemma3/templates/docker-compose.yml.j2
@@ -19,6 +19,8 @@ services:
       - --model=google/gemma-3-{{ gemma3_model_size | lower }}-it
       - --max-model-len=16384
       - --gpu-memory-utilization=0.95
+      - --enable-auto-tool-choice
+      - --tool-call-parser=pythonic
     healthcheck:
       test: ["CMD", "curl", "-f", "-s", "http://localhost:8000/v1/models"]
       interval: 10s

--- a/apps/linode-marketplace-gpt-oss/roles/gpt-oss/templates/docker-compose.yml.j2
+++ b/apps/linode-marketplace-gpt-oss/roles/gpt-oss/templates/docker-compose.yml.j2
@@ -19,6 +19,8 @@ services:
       - --model=openai/gpt-oss-{{ gpt_oss_model_size | lower }}
       - --max-model-len=16384
       - --gpu-memory-utilization=0.90
+      - --enable-auto-tool-choice
+      - --tool-call-parser=hermes
     healthcheck:
       test: ["CMD", "curl", "-f", "-s", "http://localhost:8000/v1/models"]
       interval: 10s

--- a/apps/linode-marketplace-ollama/roles/ollama/templates/docker-compose.yml.j2
+++ b/apps/linode-marketplace-ollama/roles/ollama/templates/docker-compose.yml.j2
@@ -40,6 +40,7 @@ services:
     environment:
       - OLLAMA_BASE_URL=http://ollama:11434
       - ANONYMIZED_TELEMETRY=false
+      - 'DEFAULT_MODEL_PARAMS={"function_calling":"legacy"}'
     depends_on:
       ollama:
         condition: service_started

--- a/apps/linode-marketplace-open-webui/roles/open-webui/files/docker-compose.yml
+++ b/apps/linode-marketplace-open-webui/roles/open-webui/files/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - --model=mistralai/Mistral-7B-Instruct-v0.3
       - --max-model-len=16384
       - --gpu-memory-utilization=0.95
+      - --enable-auto-tool-choice
+      - --tool-call-parser=mistral
     healthcheck:
       test: ["CMD", "curl", "-f", "-s", "http://localhost:8000/v1/models"]
       interval: 10s

--- a/apps/linode-marketplace-qwen/roles/qwen/templates/docker-compose.yml.j2
+++ b/apps/linode-marketplace-qwen/roles/qwen/templates/docker-compose.yml.j2
@@ -20,6 +20,8 @@ services:
       - --max-model-len=8192
       - --gpu-memory-utilization=0.90
       - --dtype=auto
+      - --enable-auto-tool-choice
+      - --tool-call-parser=hermes
     healthcheck:
       test: ["CMD", "curl", "-f", "-s", "http://localhost:8000/v1/models"]
       interval: 10s

--- a/tests/regression_tests/apps/linode-marketplace-deepseek/test_scenarios.py
+++ b/tests/regression_tests/apps/linode-marketplace-deepseek/test_scenarios.py
@@ -22,11 +22,13 @@ def test_deepseek_login(context, base_url, app_credentials):
     login_page.login(username, password)
     chat_page = DeepseekChatPage(context)
     chat_page.hide_release_notes()
+    chat_page.select_model(model)
     expect(chat_page.chat_input, "Chat is not visible after login.").to_be_visible()
     expect(chat_page.model_selector_input, f"{model} model is not connected").to_contain_text(model)
 
 def test_deepseek_chat(context, base_url, app_credentials):
     # Verifies that user can send prompt and get the correct response from model.
+    model = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
     prompt = "What is the capital of France?"
     expected_response = "Paris"
     username = app_credentials["Open WebUI admin email"]
@@ -36,6 +38,7 @@ def test_deepseek_chat(context, base_url, app_credentials):
     login_page.login(username, password)
     chat_page = DeepseekChatPage(context)
     chat_page.hide_release_notes()
+    chat_page.select_model(model)
     chat_page.send_prompt(prompt)
     expect(chat_page.edit_prompt_button, "Model is not responding after sending a prompt.").to_be_visible(timeout=180000)
     expect(chat_page.prompt_response_field, "Model response is not correct").to_contain_text(expected_response, timeout=180000)

--- a/tests/regression_tests/apps/linode-marketplace-gemma3/test_scenarios.py
+++ b/tests/regression_tests/apps/linode-marketplace-gemma3/test_scenarios.py
@@ -22,11 +22,13 @@ def test_gemma_login(context, base_url, app_credentials):
     login_page.login(username, password)
     chat_page = GemmaChatPage(context)
     chat_page.hide_release_notes()
+    chat_page.select_model(model)
     expect(chat_page.chat_input, "Chat is not visible after login.").to_be_visible()
     expect(chat_page.model_selector_input, f"{model} model is not connected").to_contain_text(model)
 
 def test_gemma_chat(context, base_url, app_credentials):
     # Verifies that user can send prompt and get the correct response from model.
+    model = "google/gemma-3-4b-it"
     prompt = "What is the capital of France?"
     expected_response = "Paris"
     username = app_credentials["Open WebUI admin email"]
@@ -36,6 +38,7 @@ def test_gemma_chat(context, base_url, app_credentials):
     login_page.login(username, password)
     chat_page = GemmaChatPage(context)
     chat_page.hide_release_notes()
+    chat_page.select_model(model)
     chat_page.send_prompt(prompt)
     expect(chat_page.edit_prompt_button, "Model is not responding after sending a prompt.").to_be_visible(timeout=180000)
     expect(chat_page.prompt_response_field, "Model response is not correct").to_contain_text(expected_response, timeout=180000)

--- a/tests/regression_tests/apps/linode-marketplace-gpt-oss/test_scenarios.py
+++ b/tests/regression_tests/apps/linode-marketplace-gpt-oss/test_scenarios.py
@@ -22,11 +22,13 @@ def test_gpt_login(context, base_url, app_credentials):
     login_page.login(username, password)
     chat_page = GPTChatPage(context)
     chat_page.hide_release_notes()
+    chat_page.select_model(model)
     expect(chat_page.chat_input, "Chat is not visible after login.").to_be_visible()
     expect(chat_page.model_selector_input, f"{model} model is not connected").to_contain_text(model)
 
 def test_gpt_chat(context, base_url, app_credentials):
     # Verifies that user can send prompt and get the correct response from model.
+    model = "openai/gpt-oss-20b"
     prompt = "What is the capital of France?"
     expected_response = "Paris"
     username = app_credentials["Open WebUI admin email"]
@@ -36,6 +38,7 @@ def test_gpt_chat(context, base_url, app_credentials):
     login_page.login(username, password)
     chat_page = GPTChatPage(context)
     chat_page.hide_release_notes()
+    chat_page.select_model(model)
     chat_page.send_prompt(prompt)
     expect(chat_page.edit_prompt_button, "Model is not responding after sending a prompt.").to_be_visible(timeout=180000)
     expect(chat_page.prompt_response_field, "Model response is not correct").to_contain_text(expected_response, timeout=180000)

--- a/tests/regression_tests/apps/linode-marketplace-ollama/test_scenarios.py
+++ b/tests/regression_tests/apps/linode-marketplace-ollama/test_scenarios.py
@@ -22,11 +22,13 @@ def test_ollama_login(context, base_url, app_credentials):
     login_page.login(username, password)
     chat_page = OllamaChatPage(context)
     chat_page.hide_release_notes()
+    chat_page.select_model(model)
     expect(chat_page.chat_input, "Chat is not visible after login.").to_be_visible()
     expect(chat_page.model_selector_input, f"{model} model is not connected").to_contain_text(model)
 
 def test_ollama_chat(context, base_url, app_credentials):
     # Verifies that user can send prompt and get the correct response from model.
+    model = "llama3.2:3b"
     prompt = "What is the capital of France?"
     expected_response = "Paris"
     username = app_credentials["Open WebUI admin email"]
@@ -36,6 +38,7 @@ def test_ollama_chat(context, base_url, app_credentials):
     login_page.login(username, password)
     chat_page = OllamaChatPage(context)
     chat_page.hide_release_notes()
+    chat_page.select_model(model)
     chat_page.send_prompt(prompt)
     expect(chat_page.edit_prompt_button, "Model is not responding after sending a prompt.").to_be_visible(timeout=180000)
     expect(chat_page.prompt_response_field, "Model response is not correct").to_contain_text(expected_response, timeout=180000)

--- a/tests/regression_tests/apps/linode-marketplace-open-webui/test_scenarios.py
+++ b/tests/regression_tests/apps/linode-marketplace-open-webui/test_scenarios.py
@@ -22,11 +22,13 @@ def test_mistral_login(context, base_url, app_credentials):
     login_page.login(username, password)
     chat_page = MistralChatPage(context)
     chat_page.hide_release_notes()
+    chat_page.select_model(model)
     expect(chat_page.chat_input, "Chat is not visible after login.").to_be_visible()
     expect(chat_page.model_selector_input, f"{model} model is not connected").to_contain_text(model)
 
 def test_mistral_chat(context, base_url, app_credentials):
     # Verifies that user can send prompt and get the correct response from model.
+    model = "mistralai/Mistral-7B-Instruct-v0.3"
     prompt = "What is the capital of France?"
     expected_response = "Paris"
     username = app_credentials["Open WebUI admin email"]
@@ -36,6 +38,7 @@ def test_mistral_chat(context, base_url, app_credentials):
     login_page.login(username, password)
     chat_page = MistralChatPage(context)
     chat_page.hide_release_notes()
+    chat_page.select_model(model)
     chat_page.send_prompt(prompt)
     expect(chat_page.edit_prompt_button, "Model is not responding after sending a prompt.").to_be_visible(timeout=180000)
     expect(chat_page.prompt_response_field, "Model response is not correct").to_contain_text(expected_response, timeout=180000)

--- a/tests/regression_tests/apps/linode-marketplace-qwen/test_scenarios.py
+++ b/tests/regression_tests/apps/linode-marketplace-qwen/test_scenarios.py
@@ -22,11 +22,13 @@ def test_qwen_login(context, base_url, app_credentials):
     login_page.login(username, password)
     chat_page = QwenChatPage(context)
     chat_page.hide_release_notes()
+    chat_page.select_model(model)
     expect(chat_page.chat_input, "Chat is not visible after login.").to_be_visible()
     expect(chat_page.model_selector_input, f"{model} model is not connected").to_contain_text(model)
 
 def test_qwen_chat(context, base_url, app_credentials):
     # Verifies that user can send prompt and get the correct response from model.
+    model = "Qwen/Qwen3.5-4B"
     prompt = "What is the capital of France?"
     expected_response = "Paris"
     username = app_credentials["Open WebUI admin email"]
@@ -36,6 +38,7 @@ def test_qwen_chat(context, base_url, app_credentials):
     login_page.login(username, password)
     chat_page = QwenChatPage(context)
     chat_page.hide_release_notes()
+    chat_page.select_model(model)
     chat_page.send_prompt(prompt)
     expect(chat_page.edit_prompt_button, "Model is not responding after sending a prompt.").to_be_visible(timeout=180000)
     expect(chat_page.prompt_response_field, "Model response is not correct").to_contain_text(expected_response, timeout=180000)

--- a/tests/regression_tests/pages/deepseek/deepseek_chat_page.py
+++ b/tests/regression_tests/pages/deepseek/deepseek_chat_page.py
@@ -20,6 +20,11 @@ class DeepseekChatPage(BasePage):
         except Exception:
             pass
 
+    def select_model(self, model_name: str):
+        if model_name not in self.model_selector_input.inner_text():
+            self.model_selector_input.click()
+            self.page.get_by_role("option", name=model_name, exact=False).click()
+
     def send_prompt(self, prompt: str):
         self.chat_input.fill(prompt)
         self.send_prompt_button.click()

--- a/tests/regression_tests/pages/gemma/gemma_chat_page.py
+++ b/tests/regression_tests/pages/gemma/gemma_chat_page.py
@@ -20,6 +20,11 @@ class GemmaChatPage(BasePage):
         except Exception:
             pass
 
+    def select_model(self, model_name: str):
+        if model_name not in self.model_selector_input.inner_text():
+            self.model_selector_input.click()
+            self.page.get_by_role("option", name=model_name, exact=False).click()
+
     def send_prompt(self, prompt: str):
         self.chat_input.fill(prompt)
         self.send_prompt_button.click()

--- a/tests/regression_tests/pages/gpt/gpt_chat_page.py
+++ b/tests/regression_tests/pages/gpt/gpt_chat_page.py
@@ -20,6 +20,11 @@ class GPTChatPage(BasePage):
         except Exception:
             pass
 
+    def select_model(self, model_name: str):
+        if model_name not in self.model_selector_input.inner_text():
+            self.model_selector_input.click()
+            self.page.get_by_role("option", name=model_name, exact=False).click()
+
     def send_prompt(self, prompt: str):
         self.chat_input.fill(prompt)
         self.send_prompt_button.click()

--- a/tests/regression_tests/pages/mistral/mistral_chat_page.py
+++ b/tests/regression_tests/pages/mistral/mistral_chat_page.py
@@ -20,6 +20,11 @@ class MistralChatPage(BasePage):
         except Exception:
             pass
 
+    def select_model(self, model_name: str):
+        if model_name not in self.model_selector_input.inner_text():
+            self.model_selector_input.click()
+            self.page.get_by_role("option", name=model_name, exact=False).click()
+
     def send_prompt(self, prompt: str):
         self.chat_input.fill(prompt)
         self.send_prompt_button.click()

--- a/tests/regression_tests/pages/ollama/ollama_chat_page.py
+++ b/tests/regression_tests/pages/ollama/ollama_chat_page.py
@@ -20,6 +20,11 @@ class OllamaChatPage(BasePage):
         except Exception:
             pass
 
+    def select_model(self, model_name: str):
+        if model_name not in self.model_selector_input.inner_text():
+            self.model_selector_input.click()
+            self.page.get_by_role("option", name=model_name, exact=False).click()
+
     def send_prompt(self, prompt: str):
         self.chat_input.fill(prompt)
         self.send_prompt_button.click()

--- a/tests/regression_tests/pages/qwen/qwen_chat_page.py
+++ b/tests/regression_tests/pages/qwen/qwen_chat_page.py
@@ -20,6 +20,11 @@ class QwenChatPage(BasePage):
         except Exception:
             pass
 
+    def select_model(self, model_name: str):
+        if model_name not in self.model_selector_input.inner_text():
+            self.model_selector_input.click()
+            self.page.get_by_role("option", name=model_name, exact=False).click()
+
     def send_prompt(self, prompt: str):
         self.chat_input.fill(prompt)
         self.send_prompt_button.click()


### PR DESCRIPTION
## Description

Fixes regression test failures caused by breaking changes in Open WebUI v0.10.1. Tests were passing on the previous version but began failing after the upgrade because the UI no longer auto-selects a model on load, vLLM now requires explicit tool-calling flags when `tool_choice: "auto"` is sent, and the built-in Notes API tools injected by Open WebUI confuse small models like `llama3.2:3b`.

---

## Type of Change

- [ ] New App
- [x] Bug Fix
- [ ] Update / Refactor
- [x] Tests
- [ ] Documentation
- [ ] CI/CD

---

## Linked Issues

N/A

---

## Changes

**`apps/linode-marketplace-ollama`**
- Added `DEFAULT_MODEL_PARAMS={"function_calling":"legacy"}` to the Open WebUI container in `docker-compose.yml.j2`. Open WebUI v0.10.1 injects built-in Notes API tool schemas into requests for any model that advertises tool capability. `llama3.2:3b` (3B params) cannot handle this alongside factual prompts and returns wrong answers. Setting `function_calling` to `legacy` disables native tool injection.

**`apps/linode-marketplace-deepseek`, `gemma3`, `gpt-oss`, `qwen`, `open-webui`**
- Added `--enable-auto-tool-choice` and `--tool-call-parser=<hermes|pythonic|mistral>` to vLLM startup commands. Open WebUI v0.10.1 sends `tool_choice: "auto"` in all chat requests; vLLM rejects this with a 400 unless these flags are set.

**`tests/regression_tests/pages/`** (deepseek, gemma, gpt, mistral, ollama, qwen)
- Added `select_model()` method to all chat page classes. Open WebUI v0.10.1 no longer auto-selects a model on load, so tests were stalling waiting for a response that never came.

**`tests/regression_tests/apps/`** (deepseek, gemma3, gpt-oss, ollama, open-webui, qwen)
- Updated all test scenarios to call `select_model()` before sending prompts.

---

## How to Test

Run the regression tests for any of the affected apps against a freshly deployed instance. Each test sends a factual prompt and asserts the model returns the expected keyword (e.g. `"Paris"` for "What is the capital of France?").

---

## Checklist

- [ ] Ansible lint passes
- [x] Deployed and tested end-to-end on Akamai Compute
- [x] App is reachable and functional after deployment
- [x] No hardcoded secrets, tokens, or credentials
- [ ] Documentation updated (if applicable)
- [ ] Relevant reviewers assigned

---
